### PR TITLE
sheets: Remove unused dependency and unused feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1613,7 +1613,6 @@ dependencies = [
  "chrono",
  "dirs",
  "http",
- "hyperx",
  "jsonwebtoken",
  "mime",
  "nom_pem",

--- a/google/sheets/Cargo.toml
+++ b/google/sheets/Cargo.toml
@@ -14,7 +14,6 @@ async-recursion = "^0.3.2"
 chrono = { version = "0.4", features = ["serde"] }
 dirs = { version = "^3.0.2", optional = true }
 http = "^0.2.4"
-hyperx = "1"
 jsonwebtoken = "7"
 mime = "0.3"
 percent-encoding = "2.1"

--- a/google/sheets/src/lib.rs
+++ b/google/sheets/src/lib.rs
@@ -100,7 +100,6 @@
 //!     access_token = google sheets.refresh_access_token().await.unwrap();
 //! }
 //! ```
-#![feature(async_stream)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::nonstandard_macro_braces)]
 #![allow(clippy::large_enum_variant)]


### PR DESCRIPTION
This removes the [`hyperx`](https://docs.rs/hyperx) dependency, which was unused and causes issues with dependency resolution (see dekellum/hyperx#33), from `sheets`. It also removes an unused `#![feature(async_stream)]`, allowing the crate to once again compile on stable Rust.