### PR TITLE
Fix dependency definition

### DIFF
--- a/google/drive/README.md
+++ b/google/drive/README.md
@@ -37,7 +37,7 @@ To install the library, add the following to your `Cargo.toml` file.
 
 ```toml
 [dependencies]
-google_drive = "0.2.5"
+google-drive = "0.2.5"
 ```
 
 ## Basic example


### PR DESCRIPTION
I tried `google_drive = "0.2.4"`, but that didn't exist on cargo