### PR TITLE
remove unnecessary feature requirements and fix docs generation

### DIFF
--- a/docusign/src/lib.rs
+++ b/docusign/src/lib.rs
@@ -91,7 +91,6 @@
 //!     access_token = docusign.refresh_access_token().await.unwrap();
 //! }
 //! ```
-#![feature(async_stream)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::nonstandard_macro_braces)]
 #![allow(clippy::large_enum_variant)]

--- a/generator/src/main.rs
+++ b/generator/src/main.rs
@@ -2267,7 +2267,6 @@ fn gen(
     /*
      * Deal with any dependencies we require to produce this client.
      */
-    a("#![feature(async_stream)]");
     a("#![allow(clippy::too_many_arguments)]");
     a("#![allow(clippy::nonstandard_macro_braces)]");
     a("#![allow(clippy::large_enum_variant)]");

--- a/generator/src/template.rs
+++ b/generator/src/template.rs
@@ -618,6 +618,7 @@ pub fn generate_docs_generic_token(
 ) -> String {
     let info = generate_docs_openapi_info(api, proper_name, spec_link, name);
 
+    let identifier_name = proper_name.replace(" ", "_");
     let add_post_header_args = if !add_post_header.is_empty() {
         format!(
             ",\n//!     String::from(\"{}\")",
@@ -710,20 +711,20 @@ pub fn generate_docs_generic_token(
         name.replace("_", "-").to_lowercase(),
         version,
         name,
-        proper_name.to_lowercase(),
+        identifier_name.to_lowercase(),
         add_post_header_args,
-        proper_name.to_uppercase(),
-        proper_name.to_uppercase(),
-        proper_name.to_uppercase(),
+        identifier_name.to_uppercase(),
+        identifier_name.to_uppercase(),
+        identifier_name.to_uppercase(),
         name,
-        proper_name.to_lowercase(),
+        identifier_name.to_lowercase(),
         add_post_header_args,
         name,
-        proper_name.to_lowercase(),
+        identifier_name.to_lowercase(),
         add_post_header_var,
-        proper_name.to_lowercase(),
-        proper_name.to_lowercase(),
-        proper_name.to_lowercase(),
+        identifier_name.to_lowercase(),
+        identifier_name.to_lowercase(),
+        identifier_name.to_lowercase(),
     )
 }
 

--- a/giphy/src/lib.rs
+++ b/giphy/src/lib.rs
@@ -55,7 +55,6 @@
 //!
 //! let giphy = Client::new_from_env();
 //! ```
-#![feature(async_stream)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::nonstandard_macro_braces)]
 #![allow(clippy::large_enum_variant)]

--- a/github/src/lib.rs
+++ b/github/src/lib.rs
@@ -164,7 +164,6 @@
 //! way here. This extends that effort in a generated way so the library is
 //! always up to the date with the OpenAPI spec and no longer requires manual
 //! contributions to add new endpoints.
-#![feature(async_stream)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::nonstandard_macro_braces)]
 #![allow(clippy::large_enum_variant)]

--- a/google/admin/README.md
+++ b/google/admin/README.md
@@ -48,7 +48,7 @@ a user agent string and set of credentials.
 ```
 use gsuite_api::Client;
 
-let google admin = Client::new(
+let google_admin = Client::new(
     String::from("client-id"),
     String::from("client-secret"),
     String::from("redirect-uri"),
@@ -60,16 +60,16 @@ let google admin = Client::new(
 Alternatively, the library can search for most of the variables required for
 the client in the environment:
 
-- `GOOGLE ADMIN_CLIENT_ID`
-- `GOOGLE ADMIN_CLIENT_SECRET`
-- `GOOGLE ADMIN_REDIRECT_URI`
+- `GOOGLE_ADMIN_CLIENT_ID`
+- `GOOGLE_ADMIN_CLIENT_SECRET`
+- `GOOGLE_ADMIN_REDIRECT_URI`
 
 And then you can create a client from the environment.
 
 ```
 use gsuite_api::Client;
 
-let google admin = Client::new_from_env(
+let google_admin = Client::new_from_env(
     String::from("token"),
     String::from("refresh-token")
 );
@@ -84,21 +84,21 @@ To start off a fresh client and get a `token` and `refresh_token`, use the follo
 use gsuite_api::Client;
 
 async fn do_call() {
-    let mut google admin = Client::new_from_env("", "");
+    let mut google_admin = Client::new_from_env("", "");
 
     // Get the URL to request consent from the user.
     // You can optionally pass in scopes. If none are provided, then the
     // resulting URL will not have any scopes.
-    let user_consent_url = google admin.user_consent_url(&["some-scope".to_string()]);
+    let user_consent_url = google_admin.user_consent_url(&["some-scope".to_string()]);
 
     // In your redirect URL capture the code sent and our state.
     // Send it along to the request for the token.
     let code = "thing-from-redirect-url";
     let state = "state-from-redirect-url";
-    let mut access_token = google admin.get_access_token(code, state).await.unwrap();
+    let mut access_token = google_admin.get_access_token(code, state).await.unwrap();
 
     // You can additionally refresh the access token with the following.
     // You must have a refresh token to be able to call this function.
-    access_token = google admin.refresh_access_token().await.unwrap();
+    access_token = google_admin.refresh_access_token().await.unwrap();
 }
 ```

--- a/google/admin/src/lib.rs
+++ b/google/admin/src/lib.rs
@@ -46,31 +46,28 @@
 //! ```
 //! use gsuite_api::Client;
 //!
-//! let google admin = Client::new(
+//! let google_admin = Client::new(
 //!     String::from("client-id"),
 //!     String::from("client-secret"),
 //!     String::from("redirect-uri"),
 //!     String::from("token"),
-//!     String::from("refresh-token")
+//!     String::from("refresh-token"),
 //! );
 //! ```
 //!
 //! Alternatively, the library can search for most of the variables required for
 //! the client in the environment:
 //!
-//! - `GOOGLE ADMIN_CLIENT_ID`
-//! - `GOOGLE ADMIN_CLIENT_SECRET`
-//! - `GOOGLE ADMIN_REDIRECT_URI`
+//! - `GOOGLE_ADMIN_CLIENT_ID`
+//! - `GOOGLE_ADMIN_CLIENT_SECRET`
+//! - `GOOGLE_ADMIN_REDIRECT_URI`
 //!
 //! And then you can create a client from the environment.
 //!
 //! ```
 //! use gsuite_api::Client;
 //!
-//! let google admin = Client::new_from_env(
-//!     String::from("token"),
-//!     String::from("refresh-token")
-//! );
+//! let google_admin = Client::new_from_env(String::from("token"), String::from("refresh-token"));
 //! ```
 //!
 //! It is okay to pass empty values for `token` and `refresh_token`. In
@@ -82,25 +79,24 @@
 //! use gsuite_api::Client;
 //!
 //! async fn do_call() {
-//!     let mut google admin = Client::new_from_env("", "");
+//!     let mut google_admin = Client::new_from_env("", "");
 //!
 //!     // Get the URL to request consent from the user.
 //!     // You can optionally pass in scopes. If none are provided, then the
 //!     // resulting URL will not have any scopes.
-//!     let user_consent_url = google admin.user_consent_url(&["some-scope".to_string()]);
+//!     let user_consent_url = google_admin.user_consent_url(&["some-scope".to_string()]);
 //!
 //!     // In your redirect URL capture the code sent and our state.
 //!     // Send it along to the request for the token.
 //!     let code = "thing-from-redirect-url";
 //!     let state = "state-from-redirect-url";
-//!     let mut access_token = google admin.get_access_token(code, state).await.unwrap();
+//!     let mut access_token = google_admin.get_access_token(code, state).await.unwrap();
 //!
 //!     // You can additionally refresh the access token with the following.
 //!     // You must have a refresh token to be able to call this function.
-//!     access_token = google admin.refresh_access_token().await.unwrap();
+//!     access_token = google_admin.refresh_access_token().await.unwrap();
 //! }
 //! ```
-#![feature(async_stream)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::nonstandard_macro_braces)]
 #![allow(clippy::large_enum_variant)]

--- a/google/calendar/README.md
+++ b/google/calendar/README.md
@@ -48,7 +48,7 @@ a user agent string and set of credentials.
 ```
 use google_calendar::Client;
 
-let google calendar = Client::new(
+let google_calendar = Client::new(
     String::from("client-id"),
     String::from("client-secret"),
     String::from("redirect-uri"),
@@ -60,16 +60,16 @@ let google calendar = Client::new(
 Alternatively, the library can search for most of the variables required for
 the client in the environment:
 
-- `GOOGLE CALENDAR_CLIENT_ID`
-- `GOOGLE CALENDAR_CLIENT_SECRET`
-- `GOOGLE CALENDAR_REDIRECT_URI`
+- `GOOGLE_CALENDAR_CLIENT_ID`
+- `GOOGLE_CALENDAR_CLIENT_SECRET`
+- `GOOGLE_CALENDAR_REDIRECT_URI`
 
 And then you can create a client from the environment.
 
 ```
 use google_calendar::Client;
 
-let google calendar = Client::new_from_env(
+let google_calendar = Client::new_from_env(
     String::from("token"),
     String::from("refresh-token")
 );
@@ -84,21 +84,21 @@ To start off a fresh client and get a `token` and `refresh_token`, use the follo
 use google_calendar::Client;
 
 async fn do_call() {
-    let mut google calendar = Client::new_from_env("", "");
+    let mut google_calendar = Client::new_from_env("", "");
 
     // Get the URL to request consent from the user.
     // You can optionally pass in scopes. If none are provided, then the
     // resulting URL will not have any scopes.
-    let user_consent_url = google calendar.user_consent_url(&["some-scope".to_string()]);
+    let user_consent_url = google_calendar.user_consent_url(&["some-scope".to_string()]);
 
     // In your redirect URL capture the code sent and our state.
     // Send it along to the request for the token.
     let code = "thing-from-redirect-url";
     let state = "state-from-redirect-url";
-    let mut access_token = google calendar.get_access_token(code, state).await.unwrap();
+    let mut access_token = google_calendar.get_access_token(code, state).await.unwrap();
 
     // You can additionally refresh the access token with the following.
     // You must have a refresh token to be able to call this function.
-    access_token = google calendar.refresh_access_token().await.unwrap();
+    access_token = google_calendar.refresh_access_token().await.unwrap();
 }
 ```

--- a/google/calendar/src/lib.rs
+++ b/google/calendar/src/lib.rs
@@ -46,31 +46,29 @@
 //! ```
 //! use google_calendar::Client;
 //!
-//! let google calendar = Client::new(
+//! let google_calendar = Client::new(
 //!     String::from("client-id"),
 //!     String::from("client-secret"),
 //!     String::from("redirect-uri"),
 //!     String::from("token"),
-//!     String::from("refresh-token")
+//!     String::from("refresh-token"),
 //! );
 //! ```
 //!
 //! Alternatively, the library can search for most of the variables required for
 //! the client in the environment:
 //!
-//! - `GOOGLE CALENDAR_CLIENT_ID`
-//! - `GOOGLE CALENDAR_CLIENT_SECRET`
-//! - `GOOGLE CALENDAR_REDIRECT_URI`
+//! - `GOOGLE_CALENDAR_CLIENT_ID`
+//! - `GOOGLE_CALENDAR_CLIENT_SECRET`
+//! - `GOOGLE_CALENDAR_REDIRECT_URI`
 //!
 //! And then you can create a client from the environment.
 //!
 //! ```
 //! use google_calendar::Client;
 //!
-//! let google calendar = Client::new_from_env(
-//!     String::from("token"),
-//!     String::from("refresh-token")
-//! );
+//! let google_calendar =
+//!     Client::new_from_env(String::from("token"), String::from("refresh-token"));
 //! ```
 //!
 //! It is okay to pass empty values for `token` and `refresh_token`. In
@@ -82,25 +80,24 @@
 //! use google_calendar::Client;
 //!
 //! async fn do_call() {
-//!     let mut google calendar = Client::new_from_env("", "");
+//!     let mut google_calendar = Client::new_from_env("", "");
 //!
 //!     // Get the URL to request consent from the user.
 //!     // You can optionally pass in scopes. If none are provided, then the
 //!     // resulting URL will not have any scopes.
-//!     let user_consent_url = google calendar.user_consent_url(&["some-scope".to_string()]);
+//!     let user_consent_url = google_calendar.user_consent_url(&["some-scope".to_string()]);
 //!
 //!     // In your redirect URL capture the code sent and our state.
 //!     // Send it along to the request for the token.
 //!     let code = "thing-from-redirect-url";
 //!     let state = "state-from-redirect-url";
-//!     let mut access_token = google calendar.get_access_token(code, state).await.unwrap();
+//!     let mut access_token = google_calendar.get_access_token(code, state).await.unwrap();
 //!
 //!     // You can additionally refresh the access token with the following.
 //!     // You must have a refresh token to be able to call this function.
-//!     access_token = google calendar.refresh_access_token().await.unwrap();
+//!     access_token = google_calendar.refresh_access_token().await.unwrap();
 //! }
 //! ```
-#![feature(async_stream)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::nonstandard_macro_braces)]
 #![allow(clippy::large_enum_variant)]

--- a/google/cloud-resource-manager/README.md
+++ b/google/cloud-resource-manager/README.md
@@ -48,7 +48,7 @@ a user agent string and set of credentials.
 ```
 use google_cloud_resource_manager::Client;
 
-let google cloud resource manager = Client::new(
+let google_cloud_resource_manager = Client::new(
     String::from("client-id"),
     String::from("client-secret"),
     String::from("redirect-uri"),
@@ -60,16 +60,16 @@ let google cloud resource manager = Client::new(
 Alternatively, the library can search for most of the variables required for
 the client in the environment:
 
-- `GOOGLE CLOUD RESOURCE MANAGER_CLIENT_ID`
-- `GOOGLE CLOUD RESOURCE MANAGER_CLIENT_SECRET`
-- `GOOGLE CLOUD RESOURCE MANAGER_REDIRECT_URI`
+- `GOOGLE_CLOUD_RESOURCE_MANAGER_CLIENT_ID`
+- `GOOGLE_CLOUD_RESOURCE_MANAGER_CLIENT_SECRET`
+- `GOOGLE_CLOUD_RESOURCE_MANAGER_REDIRECT_URI`
 
 And then you can create a client from the environment.
 
 ```
 use google_cloud_resource_manager::Client;
 
-let google cloud resource manager = Client::new_from_env(
+let google_cloud_resource_manager = Client::new_from_env(
     String::from("token"),
     String::from("refresh-token")
 );
@@ -84,21 +84,21 @@ To start off a fresh client and get a `token` and `refresh_token`, use the follo
 use google_cloud_resource_manager::Client;
 
 async fn do_call() {
-    let mut google cloud resource manager = Client::new_from_env("", "");
+    let mut google_cloud_resource_manager = Client::new_from_env("", "");
 
     // Get the URL to request consent from the user.
     // You can optionally pass in scopes. If none are provided, then the
     // resulting URL will not have any scopes.
-    let user_consent_url = google cloud resource manager.user_consent_url(&["some-scope".to_string()]);
+    let user_consent_url = google_cloud_resource_manager.user_consent_url(&["some-scope".to_string()]);
 
     // In your redirect URL capture the code sent and our state.
     // Send it along to the request for the token.
     let code = "thing-from-redirect-url";
     let state = "state-from-redirect-url";
-    let mut access_token = google cloud resource manager.get_access_token(code, state).await.unwrap();
+    let mut access_token = google_cloud_resource_manager.get_access_token(code, state).await.unwrap();
 
     // You can additionally refresh the access token with the following.
     // You must have a refresh token to be able to call this function.
-    access_token = google cloud resource manager.refresh_access_token().await.unwrap();
+    access_token = google_cloud_resource_manager.refresh_access_token().await.unwrap();
 }
 ```

--- a/google/cloud-resource-manager/src/lib.rs
+++ b/google/cloud-resource-manager/src/lib.rs
@@ -46,31 +46,29 @@
 //! ```
 //! use google_cloud_resource_manager::Client;
 //!
-//! let google cloud resource manager = Client::new(
+//! let google_cloud_resource_manager = Client::new(
 //!     String::from("client-id"),
 //!     String::from("client-secret"),
 //!     String::from("redirect-uri"),
 //!     String::from("token"),
-//!     String::from("refresh-token")
+//!     String::from("refresh-token"),
 //! );
 //! ```
 //!
 //! Alternatively, the library can search for most of the variables required for
 //! the client in the environment:
 //!
-//! - `GOOGLE CLOUD RESOURCE MANAGER_CLIENT_ID`
-//! - `GOOGLE CLOUD RESOURCE MANAGER_CLIENT_SECRET`
-//! - `GOOGLE CLOUD RESOURCE MANAGER_REDIRECT_URI`
+//! - `GOOGLE_CLOUD_RESOURCE_MANAGER_CLIENT_ID`
+//! - `GOOGLE_CLOUD_RESOURCE_MANAGER_CLIENT_SECRET`
+//! - `GOOGLE_CLOUD_RESOURCE_MANAGER_REDIRECT_URI`
 //!
 //! And then you can create a client from the environment.
 //!
 //! ```
 //! use google_cloud_resource_manager::Client;
 //!
-//! let google cloud resource manager = Client::new_from_env(
-//!     String::from("token"),
-//!     String::from("refresh-token")
-//! );
+//! let google_cloud_resource_manager =
+//!     Client::new_from_env(String::from("token"), String::from("refresh-token"));
 //! ```
 //!
 //! It is okay to pass empty values for `token` and `refresh_token`. In
@@ -82,25 +80,31 @@
 //! use google_cloud_resource_manager::Client;
 //!
 //! async fn do_call() {
-//!     let mut google cloud resource manager = Client::new_from_env("", "");
+//!     let mut google_cloud_resource_manager = Client::new_from_env("", "");
 //!
 //!     // Get the URL to request consent from the user.
 //!     // You can optionally pass in scopes. If none are provided, then the
 //!     // resulting URL will not have any scopes.
-//!     let user_consent_url = google cloud resource manager.user_consent_url(&["some-scope".to_string()]);
+//!     let user_consent_url =
+//!         google_cloud_resource_manager.user_consent_url(&["some-scope".to_string()]);
 //!
 //!     // In your redirect URL capture the code sent and our state.
 //!     // Send it along to the request for the token.
 //!     let code = "thing-from-redirect-url";
 //!     let state = "state-from-redirect-url";
-//!     let mut access_token = google cloud resource manager.get_access_token(code, state).await.unwrap();
+//!     let mut access_token = google_cloud_resource_manager
+//!         .get_access_token(code, state)
+//!         .await
+//!         .unwrap();
 //!
 //!     // You can additionally refresh the access token with the following.
 //!     // You must have a refresh token to be able to call this function.
-//!     access_token = google cloud resource manager.refresh_access_token().await.unwrap();
+//!     access_token = google_cloud_resource_manager
+//!         .refresh_access_token()
+//!         .await
+//!         .unwrap();
 //! }
 //! ```
-#![feature(async_stream)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::nonstandard_macro_braces)]
 #![allow(clippy::large_enum_variant)]

--- a/google/drive/README.md
+++ b/google/drive/README.md
@@ -48,7 +48,7 @@ a user agent string and set of credentials.
 ```
 use google_drive::Client;
 
-let google drive = Client::new(
+let google_drive = Client::new(
     String::from("client-id"),
     String::from("client-secret"),
     String::from("redirect-uri"),
@@ -60,16 +60,16 @@ let google drive = Client::new(
 Alternatively, the library can search for most of the variables required for
 the client in the environment:
 
-- `GOOGLE DRIVE_CLIENT_ID`
-- `GOOGLE DRIVE_CLIENT_SECRET`
-- `GOOGLE DRIVE_REDIRECT_URI`
+- `GOOGLE_DRIVE_CLIENT_ID`
+- `GOOGLE_DRIVE_CLIENT_SECRET`
+- `GOOGLE_DRIVE_REDIRECT_URI`
 
 And then you can create a client from the environment.
 
 ```
 use google_drive::Client;
 
-let google drive = Client::new_from_env(
+let google_drive = Client::new_from_env(
     String::from("token"),
     String::from("refresh-token")
 );
@@ -84,21 +84,21 @@ To start off a fresh client and get a `token` and `refresh_token`, use the follo
 use google_drive::Client;
 
 async fn do_call() {
-    let mut google drive = Client::new_from_env("", "");
+    let mut google_drive = Client::new_from_env("", "");
 
     // Get the URL to request consent from the user.
     // You can optionally pass in scopes. If none are provided, then the
     // resulting URL will not have any scopes.
-    let user_consent_url = google drive.user_consent_url(&["some-scope".to_string()]);
+    let user_consent_url = google_drive.user_consent_url(&["some-scope".to_string()]);
 
     // In your redirect URL capture the code sent and our state.
     // Send it along to the request for the token.
     let code = "thing-from-redirect-url";
     let state = "state-from-redirect-url";
-    let mut access_token = google drive.get_access_token(code, state).await.unwrap();
+    let mut access_token = google_drive.get_access_token(code, state).await.unwrap();
 
     // You can additionally refresh the access token with the following.
     // You must have a refresh token to be able to call this function.
-    access_token = google drive.refresh_access_token().await.unwrap();
+    access_token = google_drive.refresh_access_token().await.unwrap();
 }
 ```

--- a/google/drive/src/lib.rs
+++ b/google/drive/src/lib.rs
@@ -46,31 +46,28 @@
 //! ```
 //! use google_drive::Client;
 //!
-//! let google drive = Client::new(
+//! let google_drive = Client::new(
 //!     String::from("client-id"),
 //!     String::from("client-secret"),
 //!     String::from("redirect-uri"),
 //!     String::from("token"),
-//!     String::from("refresh-token")
+//!     String::from("refresh-token"),
 //! );
 //! ```
 //!
 //! Alternatively, the library can search for most of the variables required for
 //! the client in the environment:
 //!
-//! - `GOOGLE DRIVE_CLIENT_ID`
-//! - `GOOGLE DRIVE_CLIENT_SECRET`
-//! - `GOOGLE DRIVE_REDIRECT_URI`
+//! - `GOOGLE_DRIVE_CLIENT_ID`
+//! - `GOOGLE_DRIVE_CLIENT_SECRET`
+//! - `GOOGLE_DRIVE_REDIRECT_URI`
 //!
 //! And then you can create a client from the environment.
 //!
 //! ```
 //! use google_drive::Client;
 //!
-//! let google drive = Client::new_from_env(
-//!     String::from("token"),
-//!     String::from("refresh-token")
-//! );
+//! let google_drive = Client::new_from_env(String::from("token"), String::from("refresh-token"));
 //! ```
 //!
 //! It is okay to pass empty values for `token` and `refresh_token`. In
@@ -82,25 +79,24 @@
 //! use google_drive::Client;
 //!
 //! async fn do_call() {
-//!     let mut google drive = Client::new_from_env("", "");
+//!     let mut google_drive = Client::new_from_env("", "");
 //!
 //!     // Get the URL to request consent from the user.
 //!     // You can optionally pass in scopes. If none are provided, then the
 //!     // resulting URL will not have any scopes.
-//!     let user_consent_url = google drive.user_consent_url(&["some-scope".to_string()]);
+//!     let user_consent_url = google_drive.user_consent_url(&["some-scope".to_string()]);
 //!
 //!     // In your redirect URL capture the code sent and our state.
 //!     // Send it along to the request for the token.
 //!     let code = "thing-from-redirect-url";
 //!     let state = "state-from-redirect-url";
-//!     let mut access_token = google drive.get_access_token(code, state).await.unwrap();
+//!     let mut access_token = google_drive.get_access_token(code, state).await.unwrap();
 //!
 //!     // You can additionally refresh the access token with the following.
 //!     // You must have a refresh token to be able to call this function.
-//!     access_token = google drive.refresh_access_token().await.unwrap();
+//!     access_token = google_drive.refresh_access_token().await.unwrap();
 //! }
 //! ```
-#![feature(async_stream)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::nonstandard_macro_braces)]
 #![allow(clippy::large_enum_variant)]

--- a/google/groups-settings/README.md
+++ b/google/groups-settings/README.md
@@ -48,7 +48,7 @@ a user agent string and set of credentials.
 ```
 use google_groups_settings::Client;
 
-let google groups settings = Client::new(
+let google_groups_settings = Client::new(
     String::from("client-id"),
     String::from("client-secret"),
     String::from("redirect-uri"),
@@ -60,16 +60,16 @@ let google groups settings = Client::new(
 Alternatively, the library can search for most of the variables required for
 the client in the environment:
 
-- `GOOGLE GROUPS SETTINGS_CLIENT_ID`
-- `GOOGLE GROUPS SETTINGS_CLIENT_SECRET`
-- `GOOGLE GROUPS SETTINGS_REDIRECT_URI`
+- `GOOGLE_GROUPS_SETTINGS_CLIENT_ID`
+- `GOOGLE_GROUPS_SETTINGS_CLIENT_SECRET`
+- `GOOGLE_GROUPS_SETTINGS_REDIRECT_URI`
 
 And then you can create a client from the environment.
 
 ```
 use google_groups_settings::Client;
 
-let google groups settings = Client::new_from_env(
+let google_groups_settings = Client::new_from_env(
     String::from("token"),
     String::from("refresh-token")
 );
@@ -84,21 +84,21 @@ To start off a fresh client and get a `token` and `refresh_token`, use the follo
 use google_groups_settings::Client;
 
 async fn do_call() {
-    let mut google groups settings = Client::new_from_env("", "");
+    let mut google_groups_settings = Client::new_from_env("", "");
 
     // Get the URL to request consent from the user.
     // You can optionally pass in scopes. If none are provided, then the
     // resulting URL will not have any scopes.
-    let user_consent_url = google groups settings.user_consent_url(&["some-scope".to_string()]);
+    let user_consent_url = google_groups_settings.user_consent_url(&["some-scope".to_string()]);
 
     // In your redirect URL capture the code sent and our state.
     // Send it along to the request for the token.
     let code = "thing-from-redirect-url";
     let state = "state-from-redirect-url";
-    let mut access_token = google groups settings.get_access_token(code, state).await.unwrap();
+    let mut access_token = google_groups_settings.get_access_token(code, state).await.unwrap();
 
     // You can additionally refresh the access token with the following.
     // You must have a refresh token to be able to call this function.
-    access_token = google groups settings.refresh_access_token().await.unwrap();
+    access_token = google_groups_settings.refresh_access_token().await.unwrap();
 }
 ```

--- a/google/groups-settings/src/lib.rs
+++ b/google/groups-settings/src/lib.rs
@@ -46,31 +46,29 @@
 //! ```
 //! use google_groups_settings::Client;
 //!
-//! let google groups settings = Client::new(
+//! let google_groups_settings = Client::new(
 //!     String::from("client-id"),
 //!     String::from("client-secret"),
 //!     String::from("redirect-uri"),
 //!     String::from("token"),
-//!     String::from("refresh-token")
+//!     String::from("refresh-token"),
 //! );
 //! ```
 //!
 //! Alternatively, the library can search for most of the variables required for
 //! the client in the environment:
 //!
-//! - `GOOGLE GROUPS SETTINGS_CLIENT_ID`
-//! - `GOOGLE GROUPS SETTINGS_CLIENT_SECRET`
-//! - `GOOGLE GROUPS SETTINGS_REDIRECT_URI`
+//! - `GOOGLE_GROUPS_SETTINGS_CLIENT_ID`
+//! - `GOOGLE_GROUPS_SETTINGS_CLIENT_SECRET`
+//! - `GOOGLE_GROUPS_SETTINGS_REDIRECT_URI`
 //!
 //! And then you can create a client from the environment.
 //!
 //! ```
 //! use google_groups_settings::Client;
 //!
-//! let google groups settings = Client::new_from_env(
-//!     String::from("token"),
-//!     String::from("refresh-token")
-//! );
+//! let google_groups_settings =
+//!     Client::new_from_env(String::from("token"), String::from("refresh-token"));
 //! ```
 //!
 //! It is okay to pass empty values for `token` and `refresh_token`. In
@@ -82,25 +80,27 @@
 //! use google_groups_settings::Client;
 //!
 //! async fn do_call() {
-//!     let mut google groups settings = Client::new_from_env("", "");
+//!     let mut google_groups_settings = Client::new_from_env("", "");
 //!
 //!     // Get the URL to request consent from the user.
 //!     // You can optionally pass in scopes. If none are provided, then the
 //!     // resulting URL will not have any scopes.
-//!     let user_consent_url = google groups settings.user_consent_url(&["some-scope".to_string()]);
+//!     let user_consent_url = google_groups_settings.user_consent_url(&["some-scope".to_string()]);
 //!
 //!     // In your redirect URL capture the code sent and our state.
 //!     // Send it along to the request for the token.
 //!     let code = "thing-from-redirect-url";
 //!     let state = "state-from-redirect-url";
-//!     let mut access_token = google groups settings.get_access_token(code, state).await.unwrap();
+//!     let mut access_token = google_groups_settings
+//!         .get_access_token(code, state)
+//!         .await
+//!         .unwrap();
 //!
 //!     // You can additionally refresh the access token with the following.
 //!     // You must have a refresh token to be able to call this function.
-//!     access_token = google groups settings.refresh_access_token().await.unwrap();
+//!     access_token = google_groups_settings.refresh_access_token().await.unwrap();
 //! }
 //! ```
-#![feature(async_stream)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::nonstandard_macro_braces)]
 #![allow(clippy::large_enum_variant)]

--- a/google/sheets/README.md
+++ b/google/sheets/README.md
@@ -48,7 +48,7 @@ a user agent string and set of credentials.
 ```
 use sheets::Client;
 
-let google sheets = Client::new(
+let google_sheets = Client::new(
     String::from("client-id"),
     String::from("client-secret"),
     String::from("redirect-uri"),
@@ -60,16 +60,16 @@ let google sheets = Client::new(
 Alternatively, the library can search for most of the variables required for
 the client in the environment:
 
-- `GOOGLE SHEETS_CLIENT_ID`
-- `GOOGLE SHEETS_CLIENT_SECRET`
-- `GOOGLE SHEETS_REDIRECT_URI`
+- `GOOGLE_SHEETS_CLIENT_ID`
+- `GOOGLE_SHEETS_CLIENT_SECRET`
+- `GOOGLE_SHEETS_REDIRECT_URI`
 
 And then you can create a client from the environment.
 
 ```
 use sheets::Client;
 
-let google sheets = Client::new_from_env(
+let google_sheets = Client::new_from_env(
     String::from("token"),
     String::from("refresh-token")
 );
@@ -84,21 +84,21 @@ To start off a fresh client and get a `token` and `refresh_token`, use the follo
 use sheets::Client;
 
 async fn do_call() {
-    let mut google sheets = Client::new_from_env("", "");
+    let mut google_sheets = Client::new_from_env("", "");
 
     // Get the URL to request consent from the user.
     // You can optionally pass in scopes. If none are provided, then the
     // resulting URL will not have any scopes.
-    let user_consent_url = google sheets.user_consent_url(&["some-scope".to_string()]);
+    let user_consent_url = google_sheets.user_consent_url(&["some-scope".to_string()]);
 
     // In your redirect URL capture the code sent and our state.
     // Send it along to the request for the token.
     let code = "thing-from-redirect-url";
     let state = "state-from-redirect-url";
-    let mut access_token = google sheets.get_access_token(code, state).await.unwrap();
+    let mut access_token = google_sheets.get_access_token(code, state).await.unwrap();
 
     // You can additionally refresh the access token with the following.
     // You must have a refresh token to be able to call this function.
-    access_token = google sheets.refresh_access_token().await.unwrap();
+    access_token = google_sheets.refresh_access_token().await.unwrap();
 }
 ```

--- a/google/sheets/src/lib.rs
+++ b/google/sheets/src/lib.rs
@@ -46,31 +46,28 @@
 //! ```
 //! use sheets::Client;
 //!
-//! let google sheets = Client::new(
+//! let google_sheets = Client::new(
 //!     String::from("client-id"),
 //!     String::from("client-secret"),
 //!     String::from("redirect-uri"),
 //!     String::from("token"),
-//!     String::from("refresh-token")
+//!     String::from("refresh-token"),
 //! );
 //! ```
 //!
 //! Alternatively, the library can search for most of the variables required for
 //! the client in the environment:
 //!
-//! - `GOOGLE SHEETS_CLIENT_ID`
-//! - `GOOGLE SHEETS_CLIENT_SECRET`
-//! - `GOOGLE SHEETS_REDIRECT_URI`
+//! - `GOOGLE_SHEETS_CLIENT_ID`
+//! - `GOOGLE_SHEETS_CLIENT_SECRET`
+//! - `GOOGLE_SHEETS_REDIRECT_URI`
 //!
 //! And then you can create a client from the environment.
 //!
 //! ```
 //! use sheets::Client;
 //!
-//! let google sheets = Client::new_from_env(
-//!     String::from("token"),
-//!     String::from("refresh-token")
-//! );
+//! let google_sheets = Client::new_from_env(String::from("token"), String::from("refresh-token"));
 //! ```
 //!
 //! It is okay to pass empty values for `token` and `refresh_token`. In
@@ -82,25 +79,24 @@
 //! use sheets::Client;
 //!
 //! async fn do_call() {
-//!     let mut google sheets = Client::new_from_env("", "");
+//!     let mut google_sheets = Client::new_from_env("", "");
 //!
 //!     // Get the URL to request consent from the user.
 //!     // You can optionally pass in scopes. If none are provided, then the
 //!     // resulting URL will not have any scopes.
-//!     let user_consent_url = google sheets.user_consent_url(&["some-scope".to_string()]);
+//!     let user_consent_url = google_sheets.user_consent_url(&["some-scope".to_string()]);
 //!
 //!     // In your redirect URL capture the code sent and our state.
 //!     // Send it along to the request for the token.
 //!     let code = "thing-from-redirect-url";
 //!     let state = "state-from-redirect-url";
-//!     let mut access_token = google sheets.get_access_token(code, state).await.unwrap();
+//!     let mut access_token = google_sheets.get_access_token(code, state).await.unwrap();
 //!
 //!     // You can additionally refresh the access token with the following.
 //!     // You must have a refresh token to be able to call this function.
-//!     access_token = google sheets.refresh_access_token().await.unwrap();
+//!     access_token = google_sheets.refresh_access_token().await.unwrap();
 //! }
 //! ```
-#![feature(async_stream)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::nonstandard_macro_braces)]
 #![allow(clippy::large_enum_variant)]

--- a/gusto/src/lib.rs
+++ b/gusto/src/lib.rs
@@ -91,7 +91,6 @@
 //!     access_token = gusto.refresh_access_token().await.unwrap();
 //! }
 //! ```
-#![feature(async_stream)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::nonstandard_macro_braces)]
 #![allow(clippy::large_enum_variant)]

--- a/mailchimp/src/lib.rs
+++ b/mailchimp/src/lib.rs
@@ -91,7 +91,6 @@
 //!     access_token = mailchimp.refresh_access_token().await.unwrap();
 //! }
 //! ```
-#![feature(async_stream)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::nonstandard_macro_braces)]
 #![allow(clippy::large_enum_variant)]

--- a/okta/src/lib.rs
+++ b/okta/src/lib.rs
@@ -61,7 +61,6 @@
 //!
 //! let okta = Client::new_from_env();
 //! ```
-#![feature(async_stream)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::nonstandard_macro_braces)]
 #![allow(clippy::large_enum_variant)]

--- a/ramp/src/lib.rs
+++ b/ramp/src/lib.rs
@@ -87,7 +87,6 @@
 //!     access_token = ramp.refresh_access_token().await.unwrap();
 //! }
 //! ```
-#![feature(async_stream)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::nonstandard_macro_braces)]
 #![allow(clippy::large_enum_variant)]

--- a/rev.ai/src/lib.rs
+++ b/rev.ai/src/lib.rs
@@ -251,7 +251,6 @@
 //!
 //! let rev.ai = Client::new_from_env();
 //! ```
-#![feature(async_stream)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::nonstandard_macro_braces)]
 #![allow(clippy::large_enum_variant)]

--- a/sendgrid/src/lib.rs
+++ b/sendgrid/src/lib.rs
@@ -53,7 +53,6 @@
 //!
 //! let sendgrid = Client::new_from_env();
 //! ```
-#![feature(async_stream)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::nonstandard_macro_braces)]
 #![allow(clippy::large_enum_variant)]

--- a/shipbob/src/lib.rs
+++ b/shipbob/src/lib.rs
@@ -94,7 +94,6 @@
 //!     access_token = shipbob.refresh_access_token().await.unwrap();
 //! }
 //! ```
-#![feature(async_stream)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::nonstandard_macro_braces)]
 #![allow(clippy::large_enum_variant)]

--- a/shopify/src/lib.rs
+++ b/shopify/src/lib.rs
@@ -85,7 +85,6 @@
 //!     access_token = shopify.refresh_access_token().await.unwrap();
 //! }
 //! ```
-#![feature(async_stream)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::nonstandard_macro_braces)]
 #![allow(clippy::large_enum_variant)]

--- a/slack/src/lib.rs
+++ b/slack/src/lib.rs
@@ -91,7 +91,6 @@
 //!     access_token = slack.refresh_access_token().await.unwrap();
 //! }
 //! ```
-#![feature(async_stream)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::nonstandard_macro_braces)]
 #![allow(clippy::large_enum_variant)]

--- a/tripactions/src/lib.rs
+++ b/tripactions/src/lib.rs
@@ -71,7 +71,6 @@
 //!     let mut access_token = tripactions.get_access_token().await.unwrap();
 //! }
 //! ```
-#![feature(async_stream)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::nonstandard_macro_braces)]
 #![allow(clippy::large_enum_variant)]

--- a/zoom/src/lib.rs
+++ b/zoom/src/lib.rs
@@ -100,7 +100,6 @@
 //!     access_token = zoom.refresh_access_token().await.unwrap();
 //! }
 //! ```
-#![feature(async_stream)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::nonstandard_macro_braces)]
 #![allow(clippy::large_enum_variant)]


### PR DESCRIPTION
The generated crates are using `#[!feature(async_stream)]`. This prevents them from being compiled on stable Rust. 

It seems that the feature is not actually used, though (I assume, there was some copy&pasting going on here?), and it can be removed to make the crates compile on stable. 

Additionally; the documentation generation had a bug where spaces in the `proper_name` were not correctly handled, leading to examples in the readme and the docs (see https://crates.io/crates/gsuite-api):

```
use gsuite_api::Client;

let google admin = Client::new(
    String::from("client-id"),
    String::from("client-secret"),
    String::from("redirect-uri"),
    String::from("token"),
    String::from("refresh-token")
);
```
and 
> * GOOGLE ADMIN_CLIENT_ID
> * GOOGLE ADMIN_CLIENT_SECRET
> * GOOGLE ADMIN_REDIRECT_URI

This pull request adds an `identifier_name` where spaces are replaced.

Hope this is useful, please let me know if you want me to change anything :slightly_smiling_face: 

