### PR TITLE
Discover GitHub token scope

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,6 +68,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -310,6 +321,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e4f5d6e192964d498b45abee72ca445e91909094bc8e8791259e82c2a0d1aa6"
 
 [[package]]
+name = "env_logger"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -506,6 +530,18 @@ dependencies = [
  "url",
  "urlencoding",
  "uuid",
+]
+
+[[package]]
+name = "github-scopes-rs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6347cd5574187c9e7c9fac0354ab14e8614236194686423a7777bbc3273411c"
+dependencies = [
+ "anyhow",
+ "env_logger",
+ "log",
+ "reqwest",
 ]
 
 [[package]]
@@ -707,9 +743,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.6"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c06815895acec637cd6ed6e9662c935b866d20a106f8361892893a7d9234964"
+checksum = "37a82c6d637fc9515a4694bbf1cb2457b79d81ce52b3108bdeea58b07dd34a57"
 dependencies = [
  "bytes 1.1.0",
  "fnv",
@@ -747,7 +783,7 @@ checksum = "1323096b05d41827dadeaee54c9981958c0f94e670bc94ed80037d1a7b8b186b"
 dependencies = [
  "bytes 1.1.0",
  "fnv",
- "itoa",
+ "itoa 0.4.8",
 ]
 
 [[package]]
@@ -774,6 +810,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
 name = "hyper"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -788,7 +830,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa",
+ "itoa 0.4.8",
  "pin-project",
  "socket2",
  "tokio",
@@ -887,6 +929,12 @@ name = "itoa"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
+
+[[package]]
+name = "itoa"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
 
 [[package]]
 name = "js-sys"
@@ -1150,6 +1198,7 @@ dependencies = [
  "base64 0.12.3",
  "chrono",
  "dirs",
+ "github-scopes-rs",
  "http",
  "hyperx",
  "jsonwebtoken",
@@ -1505,15 +1554,16 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.4"
+version = "0.11.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "246e9f61b9bb77df069a947682be06e31ac43ea37862e244a69f177694ea6d22"
+checksum = "46a1f7aa4f35e5e8b4160449f51afc758f0ce6454315a9fa7d0d113e958c41eb"
 dependencies = [
  "base64 0.13.0",
  "bytes 1.1.0",
  "encoding_rs",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "hyper",
@@ -1838,19 +1888,19 @@ version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
 dependencies = [
- "itoa",
+ "itoa 0.4.8",
  "ryu",
  "serde",
 ]
 
 [[package]]
 name = "serde_urlencoded"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edfa57a7f8d9c1d260a549e7224100f6c43d43f9103e06dd8b4095a9b2b43ce9"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa",
+ "itoa 1.0.2",
  "ryu",
  "serde",
 ]
@@ -2088,6 +2138,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2195,16 +2254,16 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.8"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d3725d3efa29485e87311c5b699de63cde14b00ed4d256b8318aa30ca452cd"
+checksum = "f988a1a1adc2fb21f9c12aa96441da33a1728193ae0b95d2be22dbd17fcb4e5c"
 dependencies = [
  "bytes 1.1.0",
  "futures-core",
  "futures-sink",
- "log",
  "pin-project-lite",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -2430,8 +2489,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "632f73e236b219150ea279196e54e610f5dbafa5d61786303d4da54f84e47fce"
 dependencies = [
  "cfg-if",
- "serde",
- "serde_json",
  "wasm-bindgen-macro",
 ]
 
@@ -2528,6 +2585,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2535,9 +2601,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winreg"
-version = "0.7.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
 ]

--- a/github/Cargo.toml
+++ b/github/Cargo.toml
@@ -28,6 +28,8 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_urlencoded = "^0.7"
 url = { version = "2", features = ["serde"] }
+github-scopes-rs = { version = "1" }
+
 
 [dev-dependencies]
 base64 = "^0.12"

--- a/github/Cargo.toml
+++ b/github/Cargo.toml
@@ -30,7 +30,6 @@ serde_urlencoded = "^0.7"
 url = { version = "2", features = ["serde"] }
 github-scopes-rs = { version = "1" }
 
-
 [dev-dependencies]
 base64 = "^0.12"
 dirs = "^3.0.2"

--- a/github/examples/get_token_scopes.rs
+++ b/github/examples/get_token_scopes.rs
@@ -1,0 +1,18 @@
+use std::env;
+
+use anyhow::{anyhow, Result};
+use octorust::scopes;
+
+fn main() -> Result<()> {
+    let token = match env::var("GITHUB_TOKEN") {
+        Ok(t) => t,
+        Err(_e) => return Err(anyhow!("github token not provide")),
+    };
+
+    let permissions = scopes::OAuth::from_token(token.as_str())?;
+
+    if !permissions.repo.all {
+        return Err(anyhow!("`repo` permission is mandatory"));
+    }
+    Ok(())
+}

--- a/github/src/lib.rs
+++ b/github/src/lib.rs
@@ -233,6 +233,8 @@ pub mod reactions;
 pub mod repos;
 /// Provisioning of GitHub organization membership for SCIM-enabled providers.
 pub mod scim;
+/// Provides exactly what type of access you have by a given token.
+pub mod scopes;
 /// Look for stuff on GitHub.
 pub mod search;
 /// Retrieve secret scanning alerts from a repository.

--- a/github/src/scopes.rs
+++ b/github/src/scopes.rs
@@ -1,0 +1,20 @@
+use anyhow::Result;
+use github_scopes_rs::{oauth::OAuthContext, transform::GithubTokenScope};
+
+pub struct OAuth {}
+
+impl OAuth {
+    /**
+     * Scopes returns exactly what type of access you have by a given token.
+     *
+     * This function discover the exactly oauth scope permissions of the given token.
+     *
+     * **Note:** Accessing this endpoint does not count against your REST API rate limit.
+     *
+     * FROM: <https://docs.github.com/en/developers/apps/building-oauth-apps/scopes-for-oauth-apps>
+     */
+    pub fn from_token(token: &str) -> Result<GithubTokenScope> {
+        let p = OAuthContext::new(token)?;
+        Ok(p.get_scope_permissions())
+    }
+}


### PR DESCRIPTION
Hey, 
We often want to know which access the token client has before executing the API request. 
I have added a small package called [github-scopes-rs](https://docs.rs/github-scopes-rs/1.0.0/github_scopes_rs/), which allows us to get the scope of the token. 
This package returns a boolean fields struct (mapped to the GitHub checkboxes permission via the UI). 

[GitHub Scope Documentation](https://docs.github.com/en/developers/apps/building-oauth-apps/scopes-for-oauth-apps)

I have created an example file:
```rs
cargo run --example get_token_scopes
```