### PR TITLE
Fixed 422 error in list repositories for the authenticated user

### DIFF
--- a/github/src/repos.rs
+++ b/github/src/repos.rs
@@ -6768,9 +6768,9 @@ impl Repos {
      */
     pub async fn list_for_authenticated_user(
         &self,
-        visibility: crate::types::ReposListVisibility,
+        visibility: Option<crate::types::ReposListVisibility>,
         affiliation: &str,
-        type_: crate::types::ReposListType,
+        type_: Option<crate::types::ReposListType>,
         sort: crate::types::ReposListOrgSort,
         direction: crate::types::Order,
         per_page: i64,
@@ -6800,10 +6800,10 @@ impl Repos {
         if !sort.to_string().is_empty() {
             query_args.push(("sort".to_string(), sort.to_string()));
         }
-        if !type_.to_string().is_empty() {
+        if let Some(type_) = type_.filter(|type_| !type_.to_string().is_empty()) {
             query_args.push(("type".to_string(), type_.to_string()));
         }
-        if !visibility.to_string().is_empty() {
+        if let Some(visibility) = visibility.filter(|visibility| !visibility.to_string().is_empty()) {
             query_args.push(("visibility".to_string(), visibility.to_string()));
         }
         let query_ = serde_urlencoded::to_string(&query_args).unwrap();
@@ -6827,9 +6827,9 @@ impl Repos {
      */
     pub async fn list_all_for_authenticated_user(
         &self,
-        visibility: crate::types::ReposListVisibility,
+        visibility: Option<crate::types::ReposListVisibility>,
         affiliation: &str,
-        type_: crate::types::ReposListType,
+        type_: Option<crate::types::ReposListType>,
         sort: crate::types::ReposListOrgSort,
         direction: crate::types::Order,
         since: Option<chrono::DateTime<chrono::Utc>>,
@@ -6851,10 +6851,10 @@ impl Repos {
         if !sort.to_string().is_empty() {
             query_args.push(("sort".to_string(), sort.to_string()));
         }
-        if !type_.to_string().is_empty() {
+        if let Some(type_) = type_.filter(|type_| !type_.to_string().is_empty()) {
             query_args.push(("type".to_string(), type_.to_string()));
         }
-        if !visibility.to_string().is_empty() {
+        if let Some(visibility) = visibility.filter(|visibility| !visibility.to_string().is_empty()) {
             query_args.push(("visibility".to_string(), visibility.to_string()));
         }
         let query_ = serde_urlencoded::to_string(&query_args).unwrap();


### PR DESCRIPTION
In GitHub's list repo for authenticated user api, using `type` parameter along with `visibility` or `affiliation` will cause 422 error. Hence marked `ReposListVisibility` and `ReposListType` as optional params to skip in query params.

ref: https://docs.github.com/en/rest/repos/repos#list-repositories-for-the-authenticated-user
