### PR TITLE
Fix stale token usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,7 +220,7 @@ dependencies = [
 
 [[package]]
 name = "docusign"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -522,7 +522,7 @@ dependencies = [
 
 [[package]]
 name = "google-calendar"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -559,7 +559,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-resource-manager"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -596,7 +596,7 @@ dependencies = [
 
 [[package]]
 name = "google-drive"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -633,7 +633,7 @@ dependencies = [
 
 [[package]]
 name = "google-groups-settings"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -670,7 +670,7 @@ dependencies = [
 
 [[package]]
 name = "gsuite-api"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -707,7 +707,7 @@ dependencies = [
 
 [[package]]
 name = "gusto-api"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -992,7 +992,7 @@ dependencies = [
 
 [[package]]
 name = "mailchimp-api"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -1950,7 +1950,7 @@ dependencies = [
 
 [[package]]
 name = "sheets"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -2023,7 +2023,7 @@ dependencies = [
 
 [[package]]
 name = "shopify"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -2085,7 +2085,7 @@ checksum = "c307a32c1c5c437f38c7fd45d753050587732ba8628319fbdf12a7e289ccc590"
 
 [[package]]
 name = "slack-chat-api"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -2676,7 +2676,7 @@ dependencies = [
 
 [[package]]
 name = "zoom-api"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,7 @@ $(DOCUSIGN_SPEC): $(DOCUSIGN_SPEC_DIR)
 	curl -sSL $(DOCUSIGN_SPEC_REMOTE) -o $@
 
 docusign: target/debug/generator $(DOCUSIGN_SPEC)
-	./target/debug/generator -i $(DOCUSIGN_SPEC) -v 0.2.1 \
+	./target/debug/generator -i $(DOCUSIGN_SPEC) -v 0.2.2 \
 		-o docusign \
 		-n docusign \
 		--proper-name DocuSign \
@@ -217,7 +217,7 @@ $(GOOGLE_ADMIN_SPEC): $(GOOGLE_ADMIN_SPEC_DIR)
 	curl -sSL $(GOOGLE_ADMIN_SPEC_REMOTE) -o $@
 
 google-admin: target/debug/generator $(GOOGLE_ADMIN_SPEC)
-	./target/debug/generator -i $(GOOGLE_ADMIN_SPEC) -v 0.4.0 \
+	./target/debug/generator -i $(GOOGLE_ADMIN_SPEC) -v 0.4.1 \
 		-o google/admin \
 		-n gsuite-api \
 		--proper-name "Google Admin" \
@@ -236,7 +236,7 @@ $(GOOGLE_CALENDAR_SPEC): $(GOOGLE_CALENDAR_SPEC_DIR)
 	curl -sSL $(GOOGLE_CALENDAR_SPEC_REMOTE) -o $@
 
 google-calendar: target/debug/generator $(GOOGLE_CALENDAR_SPEC)
-	./target/debug/generator -i $(GOOGLE_CALENDAR_SPEC) -v 0.3.0 \
+	./target/debug/generator -i $(GOOGLE_CALENDAR_SPEC) -v 0.3.1 \
 		-o google/calendar \
 		-n google-calendar \
 		--proper-name "Google Calendar" \
@@ -255,7 +255,7 @@ $(GOOGLE_CLOUD_RESOURCE_MANAGER_SPEC): $(GOOGLE_CLOUD_RESOURCE_MANAGER_SPEC_DIR)
 	curl -sSL $(GOOGLE_CLOUD_RESOURCE_MANAGER_SPEC_REMOTE) -o $@
 
 google-cloud-resource-manager: target/debug/generator $(GOOGLE_CLOUD_RESOURCE_MANAGER_SPEC)
-	./target/debug/generator -i $(GOOGLE_CLOUD_RESOURCE_MANAGER_SPEC) -v 0.2.0 \
+	./target/debug/generator -i $(GOOGLE_CLOUD_RESOURCE_MANAGER_SPEC) -v 0.2.1 \
 		-o google/cloud-resource-manager \
 		-n google-cloud-resource-manager \
 		--proper-name "Google Cloud Resource Manager" \
@@ -274,7 +274,7 @@ $(GOOGLE_DRIVE_SPEC): $(GOOGLE_DRIVE_SPEC_DIR)
 	curl -sSL $(GOOGLE_DRIVE_SPEC_REMOTE) -o $@
 
 google-drive: target/debug/generator $(GOOGLE_DRIVE_SPEC)
-	./target/debug/generator -i $(GOOGLE_DRIVE_SPEC) -v 0.4.0 \
+	./target/debug/generator -i $(GOOGLE_DRIVE_SPEC) -v 0.4.1 \
 		-o google/drive \
 		-n google-drive \
 		--proper-name "Google Drive" \
@@ -293,7 +293,7 @@ $(GOOGLE_GROUPS_SETTINGS_SPEC): $(GOOGLE_GROUPS_SETTINGS_SPEC_DIR)
 	curl -sSL $(GOOGLE_GROUPS_SETTINGS_SPEC_REMOTE) -o $@
 
 google-groups-settings: target/debug/generator $(GOOGLE_GROUPS_SETTINGS_SPEC)
-	./target/debug/generator -i $(GOOGLE_GROUPS_SETTINGS_SPEC) -v 0.3.0 \
+	./target/debug/generator -i $(GOOGLE_GROUPS_SETTINGS_SPEC) -v 0.3.1 \
 		-o google/groups-settings \
 		-n google-groups-settings \
 		--proper-name "Google Groups Settings" \
@@ -312,7 +312,7 @@ $(GOOGLE_SHEETS_SPEC): $(GOOGLE_SHEETS_SPEC_DIR)
 	curl -sSL $(GOOGLE_SHEETS_SPEC_REMOTE) -o $@
 
 google-sheets: target/debug/generator $(GOOGLE_SHEETS_SPEC)
-	./target/debug/generator -i $(GOOGLE_SHEETS_SPEC) -v 0.4.0 \
+	./target/debug/generator -i $(GOOGLE_SHEETS_SPEC) -v 0.4.1 \
 		-o google/sheets \
 		-n sheets \
 		--proper-name "Google Sheets" \
@@ -331,7 +331,7 @@ $(GUSTO_SPEC): $(GUSTO_SPEC_DIR)
 	curl -sSL $(GUSTO_SPEC_REMOTE) -o $@
 
 gusto: target/debug/generator $(GUSTO_SPEC)
-	./target/debug/generator -i $(GUSTO_SPEC) -v 0.2.14 \
+	./target/debug/generator -i $(GUSTO_SPEC) -v 0.2.15 \
 		-o gusto \
 		-n gusto-api \
 		--proper-name Gusto \
@@ -353,7 +353,7 @@ $(MAILCHIMP_SPEC): $(MAILCHIMP_SPEC_DIR)
 		$(MAILCHIMP_SPEC_REMOTE)
 
 mailchimp: target/debug/generator $(MAILCHIMP_SPEC)
-	./target/debug/generator -i $(MAILCHIMP_SPEC) -v 0.2.1 \
+	./target/debug/generator -i $(MAILCHIMP_SPEC) -v 0.2.2 \
 		-o mailchimp \
 		-n mailchimp-api \
 		--proper-name MailChimp \
@@ -474,7 +474,7 @@ $(SHOPIFY_SPEC): $(SHOPIFY_SPEC_DIR)
 	curl -sSL $(SHOPIFY_SPEC_REMOTE) -o $@
 
 shopify: target/debug/generator $(SHOPIFY_SPEC)
-	./target/debug/generator -i $(SHOPIFY_SPEC) -v 0.1.1 \
+	./target/debug/generator -i $(SHOPIFY_SPEC) -v 0.1.2 \
 		-o shopify \
 		-n shopify \
 		--proper-name "Shopify" \
@@ -496,7 +496,7 @@ $(SLACK_SPEC): $(SLACK_SPEC_DIR)
 		$(SLACK_SPEC_REMOTE)
 
 slack: target/debug/generator $(SLACK_SPEC)
-	./target/debug/generator -i $(SLACK_SPEC) -v 0.2.1 \
+	./target/debug/generator -i $(SLACK_SPEC) -v 0.2.2 \
 		-o slack \
 		-n slack-chat-api \
 		--proper-name Slack \
@@ -556,7 +556,7 @@ $(ZOOM_SPEC): $(ZOOM_SPEC_DIR)
 		$(ZOOM_SPEC_REMOTE)
 
 zoom: target/debug/generator $(ZOOM_SPEC)
-	./target/debug/generator -i $(ZOOM_SPEC) -v 0.2.7 \
+	./target/debug/generator -i $(ZOOM_SPEC) -v 0.2.8 \
 		-o zoom \
 		-n zoom-api \
 		--proper-name Zoom \

--- a/docusign/Cargo.toml
+++ b/docusign/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "docusign"
 description = "A fully generated & opinionated API client for the DocuSign API."
-version = "0.2.1"
+version = "0.2.2"
 documentation = "https://docs.rs/docusign/"
 repository = "https://github.com/oxidecomputer/third-party-api-clients/tree/main/docusign"
 readme = "README.md"

--- a/docusign/README.md
+++ b/docusign/README.md
@@ -31,7 +31,7 @@ To install the library, add the following to your `Cargo.toml` file.
 
 ```toml
 [dependencies]
-docusign = "0.2.1"
+docusign = "0.2.2"
 ```
 
 ## Basic example

--- a/docusign/src/lib.rs
+++ b/docusign/src/lib.rs
@@ -2580,35 +2580,35 @@ impl Client {
         uri: &str,
         body: Option<reqwest::Body>,
     ) -> Result<reqwest::Response> {
-        let req = self.make_request(&method, uri, body).await?;
-
-        let resp = if self.auto_refresh {
+        if self.auto_refresh {
             let expired = self.is_expired().await;
 
             match expired {
-                // We have a known expired token, there is no point in trying to make a request
-                // without refreshing it first
+                // We have a known expired token, we know we need to perform a refresh prior to
+                // attempting to make a request
                 Some(true) => {
                     self.refresh_access_token().await?;
-                    self.client.execute(req).await?
                 }
+
                 // We have a (theoretically) known good token available. We make an optimistic
                 // attempting at the request. If the token is no longer good, then something other
                 // than the expiration is triggering the failure. We defer handling of these errors
                 // to the caller
-                Some(false) => self.client.execute(req).await?,
+                Some(false) => (),
 
                 // We do not know what state we are in. We could have a valid or expired token.
                 // Generally this means we are in one of two cases:
-                //   1. We have not yet performed a token refresh (and do not know the expiration
-                //      of the user provided token)
+                //   1. We have not yet performed a token refresh, nor has the user provided
+                //      expiration data, and therefore do not know the expiration of the user
+                //      provided token
                 //   2. The provider is returning unusable expiration times, at which point we
                 //      choose to ignore them
-                None => self.client.execute(req).await?,
+                None => (),
             }
-        } else {
-            self.client.execute(req).await?
-        };
+        }
+
+        let req = self.make_request(&method, uri, body).await?;
+        let resp = self.client.execute(req).await?;
 
         Ok(resp)
     }

--- a/docusign/src/lib.rs
+++ b/docusign/src/lib.rs
@@ -29,7 +29,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! docusign = "0.2.1"
+//! docusign = "0.2.2"
 //! ```
 //!
 //! ## Basic example

--- a/generator/src/client.rs
+++ b/generator/src/client.rs
@@ -1493,37 +1493,35 @@ async fn request_raw(
     uri: &str,
     body: Option<reqwest::Body>,
 ) -> Result<reqwest::Response> {{
-    let req = self.make_request(&method, uri, body).await?;
-
-    let resp = if self.auto_refresh {{
+    if self.auto_refresh {{
         let expired = self.is_expired().await;
 
         match expired {{
-            // We have a known expired token, there is no point in trying to make a request
-            // without refreshing it first
+            // We have a known expired token, we know we need to perform a refresh prior to
+            // attempting to make a request
             Some(true) => {{
                 self.refresh_access_token().await?;
-                self.client.execute(req).await?
             }}
+
             // We have a (theoretically) known good token available. We make an optimistic
             // attempting at the request. If the token is no longer good, then something other
             // than the expiration is triggering the failure. We defer handling of these errors
             // to the caller
-            Some(false) => self.client.execute(req).await?,
+            Some(false) => (),
 
             // We do not know what state we are in. We could have a valid or expired token.
             // Generally this means we are in one of two cases:
-            //   1. We have not yet performed a token refresh (and do not know the expiration
-            //      of the user provided token)
+            //   1. We have not yet performed a token refresh, nor has the user provided
+            //      expiration data, and therefore do not know the expiration of the user
+            //      provided token
             //   2. The provider is returning unusable expiration times, at which point we
             //      choose to ignore them
-            None => {{
-                self.client.execute(req).await?
-            }}
+            None => (),
         }}
-    }} else {{
-        self.client.execute(req).await?
-    }};
+    }}
+
+    let req = self.make_request(&method, uri, body).await?;
+    let resp = self.client.execute(req).await?;
 
     Ok(resp)
 }}"#,

--- a/google/admin/Cargo.toml
+++ b/google/admin/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "gsuite-api"
 description = "A fully generated & opinionated API client for the Google Admin API."
-version = "0.4.0"
+version = "0.4.1"
 documentation = "https://docs.rs/gsuite-api/"
 repository = "https://github.com/oxidecomputer/third-party-api-clients/tree/main/google/admin"
 readme = "README.md"

--- a/google/admin/README.md
+++ b/google/admin/README.md
@@ -37,7 +37,7 @@ To install the library, add the following to your `Cargo.toml` file.
 
 ```toml
 [dependencies]
-gsuite-api = "0.4.0"
+gsuite-api = "0.4.1"
 ```
 
 ## Basic example

--- a/google/admin/src/lib.rs
+++ b/google/admin/src/lib.rs
@@ -35,7 +35,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! gsuite-api = "0.4.0"
+//! gsuite-api = "0.4.1"
 //! ```
 //!
 //! ## Basic example

--- a/google/admin/src/lib.rs
+++ b/google/admin/src/lib.rs
@@ -565,35 +565,35 @@ impl Client {
         uri: &str,
         body: Option<reqwest::Body>,
     ) -> Result<reqwest::Response> {
-        let req = self.make_request(&method, uri, body).await?;
-
-        let resp = if self.auto_refresh {
+        if self.auto_refresh {
             let expired = self.is_expired().await;
 
             match expired {
-                // We have a known expired token, there is no point in trying to make a request
-                // without refreshing it first
+                // We have a known expired token, we know we need to perform a refresh prior to
+                // attempting to make a request
                 Some(true) => {
                     self.refresh_access_token().await?;
-                    self.client.execute(req).await?
                 }
+
                 // We have a (theoretically) known good token available. We make an optimistic
                 // attempting at the request. If the token is no longer good, then something other
                 // than the expiration is triggering the failure. We defer handling of these errors
                 // to the caller
-                Some(false) => self.client.execute(req).await?,
+                Some(false) => (),
 
                 // We do not know what state we are in. We could have a valid or expired token.
                 // Generally this means we are in one of two cases:
-                //   1. We have not yet performed a token refresh (and do not know the expiration
-                //      of the user provided token)
+                //   1. We have not yet performed a token refresh, nor has the user provided
+                //      expiration data, and therefore do not know the expiration of the user
+                //      provided token
                 //   2. The provider is returning unusable expiration times, at which point we
                 //      choose to ignore them
-                None => self.client.execute(req).await?,
+                None => (),
             }
-        } else {
-            self.client.execute(req).await?
-        };
+        }
+
+        let req = self.make_request(&method, uri, body).await?;
+        let resp = self.client.execute(req).await?;
 
         Ok(resp)
     }

--- a/google/calendar/Cargo.toml
+++ b/google/calendar/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "google-calendar"
 description = "A fully generated & opinionated API client for the Google Calendar API."
-version = "0.3.0"
+version = "0.3.1"
 documentation = "https://docs.rs/google-calendar/"
 repository = "https://github.com/oxidecomputer/third-party-api-clients/tree/main/google/calendar"
 readme = "README.md"

--- a/google/calendar/README.md
+++ b/google/calendar/README.md
@@ -37,7 +37,7 @@ To install the library, add the following to your `Cargo.toml` file.
 
 ```toml
 [dependencies]
-google-calendar = "0.3.0"
+google-calendar = "0.3.1"
 ```
 
 ## Basic example

--- a/google/calendar/src/lib.rs
+++ b/google/calendar/src/lib.rs
@@ -35,7 +35,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! google-calendar = "0.3.0"
+//! google-calendar = "0.3.1"
 //! ```
 //!
 //! ## Basic example

--- a/google/calendar/src/lib.rs
+++ b/google/calendar/src/lib.rs
@@ -553,35 +553,35 @@ impl Client {
         uri: &str,
         body: Option<reqwest::Body>,
     ) -> Result<reqwest::Response> {
-        let req = self.make_request(&method, uri, body).await?;
-
-        let resp = if self.auto_refresh {
+        if self.auto_refresh {
             let expired = self.is_expired().await;
 
             match expired {
-                // We have a known expired token, there is no point in trying to make a request
-                // without refreshing it first
+                // We have a known expired token, we know we need to perform a refresh prior to
+                // attempting to make a request
                 Some(true) => {
                     self.refresh_access_token().await?;
-                    self.client.execute(req).await?
                 }
+
                 // We have a (theoretically) known good token available. We make an optimistic
                 // attempting at the request. If the token is no longer good, then something other
                 // than the expiration is triggering the failure. We defer handling of these errors
                 // to the caller
-                Some(false) => self.client.execute(req).await?,
+                Some(false) => (),
 
                 // We do not know what state we are in. We could have a valid or expired token.
                 // Generally this means we are in one of two cases:
-                //   1. We have not yet performed a token refresh (and do not know the expiration
-                //      of the user provided token)
+                //   1. We have not yet performed a token refresh, nor has the user provided
+                //      expiration data, and therefore do not know the expiration of the user
+                //      provided token
                 //   2. The provider is returning unusable expiration times, at which point we
                 //      choose to ignore them
-                None => self.client.execute(req).await?,
+                None => (),
             }
-        } else {
-            self.client.execute(req).await?
-        };
+        }
+
+        let req = self.make_request(&method, uri, body).await?;
+        let resp = self.client.execute(req).await?;
 
         Ok(resp)
     }

--- a/google/cloud-resource-manager/Cargo.toml
+++ b/google/cloud-resource-manager/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "google-cloud-resource-manager"
 description = "A fully generated & opinionated API client for the Google Cloud Resource Manager API."
-version = "0.2.0"
+version = "0.2.1"
 documentation = "https://docs.rs/google-cloud-resource-manager/"
 repository = "https://github.com/oxidecomputer/third-party-api-clients/tree/main/google/cloud-resource-manager"
 readme = "README.md"

--- a/google/cloud-resource-manager/README.md
+++ b/google/cloud-resource-manager/README.md
@@ -37,7 +37,7 @@ To install the library, add the following to your `Cargo.toml` file.
 
 ```toml
 [dependencies]
-google-cloud-resource-manager = "0.2.0"
+google-cloud-resource-manager = "0.2.1"
 ```
 
 ## Basic example

--- a/google/cloud-resource-manager/src/lib.rs
+++ b/google/cloud-resource-manager/src/lib.rs
@@ -35,7 +35,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! google-cloud-resource-manager = "0.2.0"
+//! google-cloud-resource-manager = "0.2.1"
 //! ```
 //!
 //! ## Basic example

--- a/google/cloud-resource-manager/src/lib.rs
+++ b/google/cloud-resource-manager/src/lib.rs
@@ -547,35 +547,35 @@ impl Client {
         uri: &str,
         body: Option<reqwest::Body>,
     ) -> Result<reqwest::Response> {
-        let req = self.make_request(&method, uri, body).await?;
-
-        let resp = if self.auto_refresh {
+        if self.auto_refresh {
             let expired = self.is_expired().await;
 
             match expired {
-                // We have a known expired token, there is no point in trying to make a request
-                // without refreshing it first
+                // We have a known expired token, we know we need to perform a refresh prior to
+                // attempting to make a request
                 Some(true) => {
                     self.refresh_access_token().await?;
-                    self.client.execute(req).await?
                 }
+
                 // We have a (theoretically) known good token available. We make an optimistic
                 // attempting at the request. If the token is no longer good, then something other
                 // than the expiration is triggering the failure. We defer handling of these errors
                 // to the caller
-                Some(false) => self.client.execute(req).await?,
+                Some(false) => (),
 
                 // We do not know what state we are in. We could have a valid or expired token.
                 // Generally this means we are in one of two cases:
-                //   1. We have not yet performed a token refresh (and do not know the expiration
-                //      of the user provided token)
+                //   1. We have not yet performed a token refresh, nor has the user provided
+                //      expiration data, and therefore do not know the expiration of the user
+                //      provided token
                 //   2. The provider is returning unusable expiration times, at which point we
                 //      choose to ignore them
-                None => self.client.execute(req).await?,
+                None => (),
             }
-        } else {
-            self.client.execute(req).await?
-        };
+        }
+
+        let req = self.make_request(&method, uri, body).await?;
+        let resp = self.client.execute(req).await?;
 
         Ok(resp)
     }

--- a/google/drive/Cargo.toml
+++ b/google/drive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "google-drive"
 description = "A fully generated & opinionated API client for the Google Drive API."
-version = "0.4.0"
+version = "0.4.1"
 documentation = "https://docs.rs/google-drive/"
 repository = "https://github.com/oxidecomputer/third-party-api-clients/tree/main/google/drive"
 readme = "README.md"

--- a/google/drive/README.md
+++ b/google/drive/README.md
@@ -37,7 +37,7 @@ To install the library, add the following to your `Cargo.toml` file.
 
 ```toml
 [dependencies]
-google-drive = "0.4.0"
+google-drive = "0.4.1"
 ```
 
 ## Basic example

--- a/google/drive/src/lib.rs
+++ b/google/drive/src/lib.rs
@@ -556,35 +556,35 @@ impl Client {
         uri: &str,
         body: Option<reqwest::Body>,
     ) -> Result<reqwest::Response> {
-        let req = self.make_request(&method, uri, body).await?;
-
-        let resp = if self.auto_refresh {
+        if self.auto_refresh {
             let expired = self.is_expired().await;
 
             match expired {
-                // We have a known expired token, there is no point in trying to make a request
-                // without refreshing it first
+                // We have a known expired token, we know we need to perform a refresh prior to
+                // attempting to make a request
                 Some(true) => {
                     self.refresh_access_token().await?;
-                    self.client.execute(req).await?
                 }
+
                 // We have a (theoretically) known good token available. We make an optimistic
                 // attempting at the request. If the token is no longer good, then something other
                 // than the expiration is triggering the failure. We defer handling of these errors
                 // to the caller
-                Some(false) => self.client.execute(req).await?,
+                Some(false) => (),
 
                 // We do not know what state we are in. We could have a valid or expired token.
                 // Generally this means we are in one of two cases:
-                //   1. We have not yet performed a token refresh (and do not know the expiration
-                //      of the user provided token)
+                //   1. We have not yet performed a token refresh, nor has the user provided
+                //      expiration data, and therefore do not know the expiration of the user
+                //      provided token
                 //   2. The provider is returning unusable expiration times, at which point we
                 //      choose to ignore them
-                None => self.client.execute(req).await?,
+                None => (),
             }
-        } else {
-            self.client.execute(req).await?
-        };
+        }
+
+        let req = self.make_request(&method, uri, body).await?;
+        let resp = self.client.execute(req).await?;
 
         Ok(resp)
     }

--- a/google/drive/src/lib.rs
+++ b/google/drive/src/lib.rs
@@ -35,7 +35,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! google-drive = "0.4.0"
+//! google-drive = "0.4.1"
 //! ```
 //!
 //! ## Basic example

--- a/google/groups-settings/Cargo.toml
+++ b/google/groups-settings/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "google-groups-settings"
 description = "A fully generated & opinionated API client for the Google Groups Settings API."
-version = "0.3.0"
+version = "0.3.1"
 documentation = "https://docs.rs/google-groups-settings/"
 repository = "https://github.com/oxidecomputer/third-party-api-clients/tree/main/google/groups-settings"
 readme = "README.md"

--- a/google/groups-settings/README.md
+++ b/google/groups-settings/README.md
@@ -37,7 +37,7 @@ To install the library, add the following to your `Cargo.toml` file.
 
 ```toml
 [dependencies]
-google-groups-settings = "0.3.0"
+google-groups-settings = "0.3.1"
 ```
 
 ## Basic example

--- a/google/groups-settings/src/lib.rs
+++ b/google/groups-settings/src/lib.rs
@@ -546,35 +546,35 @@ impl Client {
         uri: &str,
         body: Option<reqwest::Body>,
     ) -> Result<reqwest::Response> {
-        let req = self.make_request(&method, uri, body).await?;
-
-        let resp = if self.auto_refresh {
+        if self.auto_refresh {
             let expired = self.is_expired().await;
 
             match expired {
-                // We have a known expired token, there is no point in trying to make a request
-                // without refreshing it first
+                // We have a known expired token, we know we need to perform a refresh prior to
+                // attempting to make a request
                 Some(true) => {
                     self.refresh_access_token().await?;
-                    self.client.execute(req).await?
                 }
+
                 // We have a (theoretically) known good token available. We make an optimistic
                 // attempting at the request. If the token is no longer good, then something other
                 // than the expiration is triggering the failure. We defer handling of these errors
                 // to the caller
-                Some(false) => self.client.execute(req).await?,
+                Some(false) => (),
 
                 // We do not know what state we are in. We could have a valid or expired token.
                 // Generally this means we are in one of two cases:
-                //   1. We have not yet performed a token refresh (and do not know the expiration
-                //      of the user provided token)
+                //   1. We have not yet performed a token refresh, nor has the user provided
+                //      expiration data, and therefore do not know the expiration of the user
+                //      provided token
                 //   2. The provider is returning unusable expiration times, at which point we
                 //      choose to ignore them
-                None => self.client.execute(req).await?,
+                None => (),
             }
-        } else {
-            self.client.execute(req).await?
-        };
+        }
+
+        let req = self.make_request(&method, uri, body).await?;
+        let resp = self.client.execute(req).await?;
 
         Ok(resp)
     }

--- a/google/groups-settings/src/lib.rs
+++ b/google/groups-settings/src/lib.rs
@@ -35,7 +35,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! google-groups-settings = "0.3.0"
+//! google-groups-settings = "0.3.1"
 //! ```
 //!
 //! ## Basic example

--- a/google/sheets/Cargo.toml
+++ b/google/sheets/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sheets"
 description = "A fully generated & opinionated API client for the Google Sheets API."
-version = "0.4.0"
+version = "0.4.1"
 documentation = "https://docs.rs/sheets/"
 repository = "https://github.com/oxidecomputer/third-party-api-clients/tree/main/google/sheets"
 readme = "README.md"

--- a/google/sheets/README.md
+++ b/google/sheets/README.md
@@ -37,7 +37,7 @@ To install the library, add the following to your `Cargo.toml` file.
 
 ```toml
 [dependencies]
-sheets = "0.4.0"
+sheets = "0.4.1"
 ```
 
 ## Basic example

--- a/google/sheets/src/lib.rs
+++ b/google/sheets/src/lib.rs
@@ -35,7 +35,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! sheets = "0.4.0"
+//! sheets = "0.4.1"
 //! ```
 //!
 //! ## Basic example

--- a/google/sheets/src/lib.rs
+++ b/google/sheets/src/lib.rs
@@ -547,35 +547,35 @@ impl Client {
         uri: &str,
         body: Option<reqwest::Body>,
     ) -> Result<reqwest::Response> {
-        let req = self.make_request(&method, uri, body).await?;
-
-        let resp = if self.auto_refresh {
+        if self.auto_refresh {
             let expired = self.is_expired().await;
 
             match expired {
-                // We have a known expired token, there is no point in trying to make a request
-                // without refreshing it first
+                // We have a known expired token, we know we need to perform a refresh prior to
+                // attempting to make a request
                 Some(true) => {
                     self.refresh_access_token().await?;
-                    self.client.execute(req).await?
                 }
+
                 // We have a (theoretically) known good token available. We make an optimistic
                 // attempting at the request. If the token is no longer good, then something other
                 // than the expiration is triggering the failure. We defer handling of these errors
                 // to the caller
-                Some(false) => self.client.execute(req).await?,
+                Some(false) => (),
 
                 // We do not know what state we are in. We could have a valid or expired token.
                 // Generally this means we are in one of two cases:
-                //   1. We have not yet performed a token refresh (and do not know the expiration
-                //      of the user provided token)
+                //   1. We have not yet performed a token refresh, nor has the user provided
+                //      expiration data, and therefore do not know the expiration of the user
+                //      provided token
                 //   2. The provider is returning unusable expiration times, at which point we
                 //      choose to ignore them
-                None => self.client.execute(req).await?,
+                None => (),
             }
-        } else {
-            self.client.execute(req).await?
-        };
+        }
+
+        let req = self.make_request(&method, uri, body).await?;
+        let resp = self.client.execute(req).await?;
 
         Ok(resp)
     }

--- a/gusto/Cargo.toml
+++ b/gusto/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "gusto-api"
 description = "A fully generated & opinionated API client for the Gusto API."
-version = "0.2.14"
+version = "0.2.15"
 documentation = "https://docs.rs/gusto-api/"
 repository = "https://github.com/oxidecomputer/third-party-api-clients/tree/main/gusto"
 readme = "README.md"

--- a/gusto/README.md
+++ b/gusto/README.md
@@ -31,7 +31,7 @@ To install the library, add the following to your `Cargo.toml` file.
 
 ```toml
 [dependencies]
-gusto-api = "0.2.14"
+gusto-api = "0.2.15"
 ```
 
 ## Basic example

--- a/gusto/src/lib.rs
+++ b/gusto/src/lib.rs
@@ -29,7 +29,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! gusto-api = "0.2.14"
+//! gusto-api = "0.2.15"
 //! ```
 //!
 //! ## Basic example

--- a/gusto/src/lib.rs
+++ b/gusto/src/lib.rs
@@ -523,35 +523,35 @@ impl Client {
         uri: &str,
         body: Option<reqwest::Body>,
     ) -> Result<reqwest::Response> {
-        let req = self.make_request(&method, uri, body).await?;
-
-        let resp = if self.auto_refresh {
+        if self.auto_refresh {
             let expired = self.is_expired().await;
 
             match expired {
-                // We have a known expired token, there is no point in trying to make a request
-                // without refreshing it first
+                // We have a known expired token, we know we need to perform a refresh prior to
+                // attempting to make a request
                 Some(true) => {
                     self.refresh_access_token().await?;
-                    self.client.execute(req).await?
                 }
+
                 // We have a (theoretically) known good token available. We make an optimistic
                 // attempting at the request. If the token is no longer good, then something other
                 // than the expiration is triggering the failure. We defer handling of these errors
                 // to the caller
-                Some(false) => self.client.execute(req).await?,
+                Some(false) => (),
 
                 // We do not know what state we are in. We could have a valid or expired token.
                 // Generally this means we are in one of two cases:
-                //   1. We have not yet performed a token refresh (and do not know the expiration
-                //      of the user provided token)
+                //   1. We have not yet performed a token refresh, nor has the user provided
+                //      expiration data, and therefore do not know the expiration of the user
+                //      provided token
                 //   2. The provider is returning unusable expiration times, at which point we
                 //      choose to ignore them
-                None => self.client.execute(req).await?,
+                None => (),
             }
-        } else {
-            self.client.execute(req).await?
-        };
+        }
+
+        let req = self.make_request(&method, uri, body).await?;
+        let resp = self.client.execute(req).await?;
 
         Ok(resp)
     }

--- a/mailchimp/Cargo.toml
+++ b/mailchimp/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mailchimp-api"
 description = "A fully generated & opinionated API client for the MailChimp API."
-version = "0.2.1"
+version = "0.2.2"
 documentation = "https://docs.rs/mailchimp-api/"
 repository = "https://github.com/oxidecomputer/third-party-api-clients/tree/main/mailchimp"
 readme = "README.md"

--- a/mailchimp/README.md
+++ b/mailchimp/README.md
@@ -31,7 +31,7 @@ To install the library, add the following to your `Cargo.toml` file.
 
 ```toml
 [dependencies]
-mailchimp-api = "0.2.1"
+mailchimp-api = "0.2.2"
 ```
 
 ## Basic example

--- a/mailchimp/src/lib.rs
+++ b/mailchimp/src/lib.rs
@@ -530,35 +530,35 @@ impl Client {
         uri: &str,
         body: Option<reqwest::Body>,
     ) -> Result<reqwest::Response> {
-        let req = self.make_request(&method, uri, body).await?;
-
-        let resp = if self.auto_refresh {
+        if self.auto_refresh {
             let expired = self.is_expired().await;
 
             match expired {
-                // We have a known expired token, there is no point in trying to make a request
-                // without refreshing it first
+                // We have a known expired token, we know we need to perform a refresh prior to
+                // attempting to make a request
                 Some(true) => {
                     self.refresh_access_token().await?;
-                    self.client.execute(req).await?
                 }
+
                 // We have a (theoretically) known good token available. We make an optimistic
                 // attempting at the request. If the token is no longer good, then something other
                 // than the expiration is triggering the failure. We defer handling of these errors
                 // to the caller
-                Some(false) => self.client.execute(req).await?,
+                Some(false) => (),
 
                 // We do not know what state we are in. We could have a valid or expired token.
                 // Generally this means we are in one of two cases:
-                //   1. We have not yet performed a token refresh (and do not know the expiration
-                //      of the user provided token)
+                //   1. We have not yet performed a token refresh, nor has the user provided
+                //      expiration data, and therefore do not know the expiration of the user
+                //      provided token
                 //   2. The provider is returning unusable expiration times, at which point we
                 //      choose to ignore them
-                None => self.client.execute(req).await?,
+                None => (),
             }
-        } else {
-            self.client.execute(req).await?
-        };
+        }
+
+        let req = self.make_request(&method, uri, body).await?;
+        let resp = self.client.execute(req).await?;
 
         Ok(resp)
     }

--- a/mailchimp/src/lib.rs
+++ b/mailchimp/src/lib.rs
@@ -29,7 +29,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! mailchimp-api = "0.2.1"
+//! mailchimp-api = "0.2.2"
 //! ```
 //!
 //! ## Basic example

--- a/shopify/Cargo.toml
+++ b/shopify/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "shopify"
 description = "A fully generated & opinionated API client for the Shopify API."
-version = "0.1.1"
+version = "0.1.2"
 documentation = "https://docs.rs/shopify/"
 repository = "https://github.com/oxidecomputer/third-party-api-clients/tree/main/shopify"
 readme = "README.md"

--- a/shopify/README.md
+++ b/shopify/README.md
@@ -25,7 +25,7 @@ To install the library, add the following to your `Cargo.toml` file.
 
 ```toml
 [dependencies]
-shopify = "0.1.1"
+shopify = "0.1.2"
 ```
 
 ## Basic example

--- a/shopify/src/lib.rs
+++ b/shopify/src/lib.rs
@@ -23,7 +23,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! shopify = "0.1.1"
+//! shopify = "0.1.2"
 //! ```
 //!
 //! ## Basic example

--- a/shopify/src/lib.rs
+++ b/shopify/src/lib.rs
@@ -517,35 +517,35 @@ impl Client {
         uri: &str,
         body: Option<reqwest::Body>,
     ) -> Result<reqwest::Response> {
-        let req = self.make_request(&method, uri, body).await?;
-
-        let resp = if self.auto_refresh {
+        if self.auto_refresh {
             let expired = self.is_expired().await;
 
             match expired {
-                // We have a known expired token, there is no point in trying to make a request
-                // without refreshing it first
+                // We have a known expired token, we know we need to perform a refresh prior to
+                // attempting to make a request
                 Some(true) => {
                     self.refresh_access_token().await?;
-                    self.client.execute(req).await?
                 }
+
                 // We have a (theoretically) known good token available. We make an optimistic
                 // attempting at the request. If the token is no longer good, then something other
                 // than the expiration is triggering the failure. We defer handling of these errors
                 // to the caller
-                Some(false) => self.client.execute(req).await?,
+                Some(false) => (),
 
                 // We do not know what state we are in. We could have a valid or expired token.
                 // Generally this means we are in one of two cases:
-                //   1. We have not yet performed a token refresh (and do not know the expiration
-                //      of the user provided token)
+                //   1. We have not yet performed a token refresh, nor has the user provided
+                //      expiration data, and therefore do not know the expiration of the user
+                //      provided token
                 //   2. The provider is returning unusable expiration times, at which point we
                 //      choose to ignore them
-                None => self.client.execute(req).await?,
+                None => (),
             }
-        } else {
-            self.client.execute(req).await?
-        };
+        }
+
+        let req = self.make_request(&method, uri, body).await?;
+        let resp = self.client.execute(req).await?;
 
         Ok(resp)
     }

--- a/slack/Cargo.toml
+++ b/slack/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "slack-chat-api"
 description = "A fully generated & opinionated API client for the Slack API."
-version = "0.2.1"
+version = "0.2.2"
 documentation = "https://docs.rs/slack-chat-api/"
 repository = "https://github.com/oxidecomputer/third-party-api-clients/tree/main/slack"
 readme = "README.md"

--- a/slack/README.md
+++ b/slack/README.md
@@ -31,7 +31,7 @@ To install the library, add the following to your `Cargo.toml` file.
 
 ```toml
 [dependencies]
-slack-chat-api = "0.2.1"
+slack-chat-api = "0.2.2"
 ```
 
 ## Basic example

--- a/slack/src/lib.rs
+++ b/slack/src/lib.rs
@@ -559,35 +559,35 @@ impl Client {
         uri: &str,
         body: Option<reqwest::Body>,
     ) -> Result<reqwest::Response> {
-        let req = self.make_request(&method, uri, body).await?;
-
-        let resp = if self.auto_refresh {
+        if self.auto_refresh {
             let expired = self.is_expired().await;
 
             match expired {
-                // We have a known expired token, there is no point in trying to make a request
-                // without refreshing it first
+                // We have a known expired token, we know we need to perform a refresh prior to
+                // attempting to make a request
                 Some(true) => {
                     self.refresh_access_token().await?;
-                    self.client.execute(req).await?
                 }
+
                 // We have a (theoretically) known good token available. We make an optimistic
                 // attempting at the request. If the token is no longer good, then something other
                 // than the expiration is triggering the failure. We defer handling of these errors
                 // to the caller
-                Some(false) => self.client.execute(req).await?,
+                Some(false) => (),
 
                 // We do not know what state we are in. We could have a valid or expired token.
                 // Generally this means we are in one of two cases:
-                //   1. We have not yet performed a token refresh (and do not know the expiration
-                //      of the user provided token)
+                //   1. We have not yet performed a token refresh, nor has the user provided
+                //      expiration data, and therefore do not know the expiration of the user
+                //      provided token
                 //   2. The provider is returning unusable expiration times, at which point we
                 //      choose to ignore them
-                None => self.client.execute(req).await?,
+                None => (),
             }
-        } else {
-            self.client.execute(req).await?
-        };
+        }
+
+        let req = self.make_request(&method, uri, body).await?;
+        let resp = self.client.execute(req).await?;
 
         Ok(resp)
     }

--- a/slack/src/lib.rs
+++ b/slack/src/lib.rs
@@ -29,7 +29,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! slack-chat-api = "0.2.1"
+//! slack-chat-api = "0.2.2"
 //! ```
 //!
 //! ## Basic example

--- a/zoom/Cargo.toml
+++ b/zoom/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zoom-api"
 description = "A fully generated & opinionated API client for the Zoom API."
-version = "0.2.7"
+version = "0.2.8"
 documentation = "https://docs.rs/zoom-api/"
 repository = "https://github.com/oxidecomputer/third-party-api-clients/tree/main/zoom"
 readme = "README.md"

--- a/zoom/README.md
+++ b/zoom/README.md
@@ -40,7 +40,7 @@ To install the library, add the following to your `Cargo.toml` file.
 
 ```toml
 [dependencies]
-zoom-api = "0.2.7"
+zoom-api = "0.2.8"
 ```
 
 ## Basic example

--- a/zoom/src/lib.rs
+++ b/zoom/src/lib.rs
@@ -551,35 +551,35 @@ impl Client {
         uri: &str,
         body: Option<reqwest::Body>,
     ) -> Result<reqwest::Response> {
-        let req = self.make_request(&method, uri, body).await?;
-
-        let resp = if self.auto_refresh {
+        if self.auto_refresh {
             let expired = self.is_expired().await;
 
             match expired {
-                // We have a known expired token, there is no point in trying to make a request
-                // without refreshing it first
+                // We have a known expired token, we know we need to perform a refresh prior to
+                // attempting to make a request
                 Some(true) => {
                     self.refresh_access_token().await?;
-                    self.client.execute(req).await?
                 }
+
                 // We have a (theoretically) known good token available. We make an optimistic
                 // attempting at the request. If the token is no longer good, then something other
                 // than the expiration is triggering the failure. We defer handling of these errors
                 // to the caller
-                Some(false) => self.client.execute(req).await?,
+                Some(false) => (),
 
                 // We do not know what state we are in. We could have a valid or expired token.
                 // Generally this means we are in one of two cases:
-                //   1. We have not yet performed a token refresh (and do not know the expiration
-                //      of the user provided token)
+                //   1. We have not yet performed a token refresh, nor has the user provided
+                //      expiration data, and therefore do not know the expiration of the user
+                //      provided token
                 //   2. The provider is returning unusable expiration times, at which point we
                 //      choose to ignore them
-                None => self.client.execute(req).await?,
+                None => (),
             }
-        } else {
-            self.client.execute(req).await?
-        };
+        }
+
+        let req = self.make_request(&method, uri, body).await?;
+        let resp = self.client.execute(req).await?;
 
         Ok(resp)
     }

--- a/zoom/src/lib.rs
+++ b/zoom/src/lib.rs
@@ -38,7 +38,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! zoom-api = "0.2.7"
+//! zoom-api = "0.2.8"
 //! ```
 //!
 //! ## Basic example


### PR DESCRIPTION
Clients that support token refreshing do not correctly refresh their token when it is first identified as stale. Due to the request being created prior to refreshing the token, the stale token value is being used. This defers request creation until after refresh attempts have been executed..