### PR TITLE
Allow using different version of opentelemetry

### DIFF
--- a/docusign/Cargo.toml
+++ b/docusign/Cargo.toml
@@ -32,7 +32,7 @@ reqwest = { version = "0.11.11", default-features = false, features = ["json", "
 reqwest-conditional-middleware = "0.1.0"
 reqwest-middleware = "0.1.5"
 reqwest-retry = "0.1.4"
-reqwest-tracing = { version = "0.3.0" }
+reqwest-tracing = "0.3.0"
 ring = { version = "0.16", default-features = false, optional = true }
 schemars = { version = "0.8", features = ["bytes", "chrono", "url", "uuid1"] }
 serde = { version = "1", features = ["derive"] }

--- a/docusign/Cargo.toml
+++ b/docusign/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 license = "MIT"
 
 [features]
-default = ["rustls-tls"]
+default = ["rustls-tls", "reqwest-tracing/opentelemetry_0_17"]
 # enable etag-based http_cache functionality
 httpcache = ["dirs"]
 native-tls = ["reqwest/default-tls", "openssl"]
@@ -32,7 +32,7 @@ reqwest = { version = "0.11.11", default-features = false, features = ["json", "
 reqwest-conditional-middleware = "0.1.0"
 reqwest-middleware = "0.1.5"
 reqwest-retry = "0.1.4"
-reqwest-tracing = { version = "0.3.0", features = ["opentelemetry_0_17"] }
+reqwest-tracing = { version = "0.3.0" }
 ring = { version = "0.16", default-features = false, optional = true }
 schemars = { version = "0.8", features = ["bytes", "chrono", "url", "uuid1"] }
 serde = { version = "1", features = ["derive"] }

--- a/generator/src/main.rs
+++ b/generator/src/main.rs
@@ -3255,7 +3255,7 @@ reqwest = {{ version = "0.11.11", default-features = false, features = ["json", 
 reqwest-conditional-middleware = "0.1.0"
 reqwest-middleware = "0.1.5"
 reqwest-retry = "0.1.4"
-reqwest-tracing = {{ version = "0.3.0" }}
+reqwest-tracing = "0.3.0"
 ring = {{ version = "0.16", default-features = false, optional = true }}
 schemars = {{ version = "0.8", features = ["bytes", "chrono", "url", "uuid1"] }}
 serde = {{ version = "1", features = ["derive"] }}

--- a/generator/src/main.rs
+++ b/generator/src/main.rs
@@ -3232,7 +3232,7 @@ edition = "2018"
 license = "MIT"
 
 [features]
-default = ["rustls-tls"]
+default = ["rustls-tls", "reqwest-tracing/opentelemetry_0_17"]
 # enable etag-based http_cache functionality
 httpcache = ["dirs"]
 native-tls = ["reqwest/default-tls", "openssl"]
@@ -3255,7 +3255,7 @@ reqwest = {{ version = "0.11.11", default-features = false, features = ["json", 
 reqwest-conditional-middleware = "0.1.0"
 reqwest-middleware = "0.1.5"
 reqwest-retry = "0.1.4"
-reqwest-tracing = {{ version = "0.3.0", features = ["opentelemetry_0_17"] }}
+reqwest-tracing = {{ version = "0.3.0" }}
 ring = {{ version = "0.16", default-features = false, optional = true }}
 schemars = {{ version = "0.8", features = ["bytes", "chrono", "url", "uuid1"] }}
 serde = {{ version = "1", features = ["derive"] }}

--- a/giphy/Cargo.toml
+++ b/giphy/Cargo.toml
@@ -32,7 +32,7 @@ reqwest = { version = "0.11.11", default-features = false, features = ["json", "
 reqwest-conditional-middleware = "0.1.0"
 reqwest-middleware = "0.1.5"
 reqwest-retry = "0.1.4"
-reqwest-tracing = { version = "0.3.0" }
+reqwest-tracing = "0.3.0"
 ring = { version = "0.16", default-features = false, optional = true }
 schemars = { version = "0.8", features = ["bytes", "chrono", "url", "uuid1"] }
 serde = { version = "1", features = ["derive"] }

--- a/giphy/Cargo.toml
+++ b/giphy/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 license = "MIT"
 
 [features]
-default = ["rustls-tls"]
+default = ["rustls-tls", "reqwest-tracing/opentelemetry_0_17"]
 # enable etag-based http_cache functionality
 httpcache = ["dirs"]
 native-tls = ["reqwest/default-tls", "openssl"]
@@ -32,7 +32,7 @@ reqwest = { version = "0.11.11", default-features = false, features = ["json", "
 reqwest-conditional-middleware = "0.1.0"
 reqwest-middleware = "0.1.5"
 reqwest-retry = "0.1.4"
-reqwest-tracing = { version = "0.3.0", features = ["opentelemetry_0_17"] }
+reqwest-tracing = { version = "0.3.0" }
 ring = { version = "0.16", default-features = false, optional = true }
 schemars = { version = "0.8", features = ["bytes", "chrono", "url", "uuid1"] }
 serde = { version = "1", features = ["derive"] }

--- a/github/Cargo.toml
+++ b/github/Cargo.toml
@@ -32,7 +32,7 @@ reqwest = { version = "0.11.11", default-features = false, features = ["json", "
 reqwest-conditional-middleware = "0.1.0"
 reqwest-middleware = "0.1.5"
 reqwest-retry = "0.1.4"
-reqwest-tracing = { version = "0.3.0" }
+reqwest-tracing = "0.3.0"
 ring = { version = "0.16", default-features = false, optional = true }
 schemars = { version = "0.8", features = ["bytes", "chrono", "url", "uuid1"] }
 serde = { version = "1", features = ["derive"] }

--- a/github/Cargo.toml
+++ b/github/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 license = "MIT"
 
 [features]
-default = ["rustls-tls"]
+default = ["rustls-tls", "reqwest-tracing/opentelemetry_0_17"]
 # enable etag-based http_cache functionality
 httpcache = ["dirs"]
 native-tls = ["reqwest/default-tls", "openssl"]
@@ -32,7 +32,7 @@ reqwest = { version = "0.11.11", default-features = false, features = ["json", "
 reqwest-conditional-middleware = "0.1.0"
 reqwest-middleware = "0.1.5"
 reqwest-retry = "0.1.4"
-reqwest-tracing = { version = "0.3.0", features = ["opentelemetry_0_17"] }
+reqwest-tracing = { version = "0.3.0" }
 ring = { version = "0.16", default-features = false, optional = true }
 schemars = { version = "0.8", features = ["bytes", "chrono", "url", "uuid1"] }
 serde = { version = "1", features = ["derive"] }

--- a/google/admin/Cargo.toml
+++ b/google/admin/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 license = "MIT"
 
 [features]
-default = ["rustls-tls"]
+default = ["rustls-tls", "reqwest-tracing/opentelemetry_0_17"]
 # enable etag-based http_cache functionality
 httpcache = ["dirs"]
 native-tls = ["reqwest/default-tls", "openssl"]
@@ -32,7 +32,7 @@ reqwest = { version = "0.11.11", default-features = false, features = ["json", "
 reqwest-conditional-middleware = "0.1.0"
 reqwest-middleware = "0.1.5"
 reqwest-retry = "0.1.4"
-reqwest-tracing = { version = "0.3.0", features = ["opentelemetry_0_17"] }
+reqwest-tracing = "0.3.0"
 ring = { version = "0.16", default-features = false, optional = true }
 schemars = { version = "0.8", features = ["bytes", "chrono", "url", "uuid1"] }
 serde = { version = "1", features = ["derive"] }

--- a/google/calendar/Cargo.toml
+++ b/google/calendar/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 license = "MIT"
 
 [features]
-default = ["rustls-tls"]
+default = ["rustls-tls", "reqwest-tracing/opentelemetry_0_17"]
 # enable etag-based http_cache functionality
 httpcache = ["dirs"]
 native-tls = ["reqwest/default-tls", "openssl"]
@@ -32,7 +32,7 @@ reqwest = { version = "0.11.11", default-features = false, features = ["json", "
 reqwest-conditional-middleware = "0.1.0"
 reqwest-middleware = "0.1.5"
 reqwest-retry = "0.1.4"
-reqwest-tracing = { version = "0.3.0", features = ["opentelemetry_0_17"] }
+reqwest-tracing = "0.3.0"
 ring = { version = "0.16", default-features = false, optional = true }
 schemars = { version = "0.8", features = ["bytes", "chrono", "url", "uuid1"] }
 serde = { version = "1", features = ["derive"] }

--- a/google/cloud-resource-manager/Cargo.toml
+++ b/google/cloud-resource-manager/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 license = "MIT"
 
 [features]
-default = ["rustls-tls"]
+default = ["rustls-tls", "reqwest-tracing/opentelemetry_0_17"]
 # enable etag-based http_cache functionality
 httpcache = ["dirs"]
 native-tls = ["reqwest/default-tls", "openssl"]
@@ -32,7 +32,7 @@ reqwest = { version = "0.11.11", default-features = false, features = ["json", "
 reqwest-conditional-middleware = "0.1.0"
 reqwest-middleware = "0.1.5"
 reqwest-retry = "0.1.4"
-reqwest-tracing = { version = "0.3.0", features = ["opentelemetry_0_17"] }
+reqwest-tracing = "0.3.0"
 ring = { version = "0.16", default-features = false, optional = true }
 schemars = { version = "0.8", features = ["bytes", "chrono", "url", "uuid1"] }
 serde = { version = "1", features = ["derive"] }

--- a/google/drive/Cargo.toml
+++ b/google/drive/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 license = "MIT"
 
 [features]
-default = ["rustls-tls"]
+default = ["rustls-tls", "reqwest-tracing/opentelemetry_0_17"]
 # enable etag-based http_cache functionality
 httpcache = ["dirs"]
 native-tls = ["reqwest/default-tls", "openssl"]
@@ -32,7 +32,7 @@ reqwest = { version = "0.11.11", default-features = false, features = ["json", "
 reqwest-conditional-middleware = "0.1.0"
 reqwest-middleware = "0.1.5"
 reqwest-retry = "0.1.4"
-reqwest-tracing = { version = "0.3.0", features = ["opentelemetry_0_17"] }
+reqwest-tracing = "0.3.0"
 ring = { version = "0.16", default-features = false, optional = true }
 schemars = { version = "0.8", features = ["bytes", "chrono", "url", "uuid1"] }
 serde = { version = "1", features = ["derive"] }

--- a/google/groups-settings/Cargo.toml
+++ b/google/groups-settings/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 license = "MIT"
 
 [features]
-default = ["rustls-tls"]
+default = ["rustls-tls", "reqwest-tracing/opentelemetry_0_17"]
 # enable etag-based http_cache functionality
 httpcache = ["dirs"]
 native-tls = ["reqwest/default-tls", "openssl"]
@@ -32,7 +32,7 @@ reqwest = { version = "0.11.11", default-features = false, features = ["json", "
 reqwest-conditional-middleware = "0.1.0"
 reqwest-middleware = "0.1.5"
 reqwest-retry = "0.1.4"
-reqwest-tracing = { version = "0.3.0", features = ["opentelemetry_0_17"] }
+reqwest-tracing = "0.3.0"
 ring = { version = "0.16", default-features = false, optional = true }
 schemars = { version = "0.8", features = ["bytes", "chrono", "url", "uuid1"] }
 serde = { version = "1", features = ["derive"] }

--- a/google/sheets/Cargo.toml
+++ b/google/sheets/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 license = "MIT"
 
 [features]
-default = ["rustls-tls"]
+default = ["rustls-tls", "reqwest-tracing/opentelemetry_0_17"]
 # enable etag-based http_cache functionality
 httpcache = ["dirs"]
 native-tls = ["reqwest/default-tls", "openssl"]
@@ -32,7 +32,7 @@ reqwest = { version = "0.11.11", default-features = false, features = ["json", "
 reqwest-conditional-middleware = "0.1.0"
 reqwest-middleware = "0.1.5"
 reqwest-retry = "0.1.4"
-reqwest-tracing = { version = "0.3.0", features = ["opentelemetry_0_17"] }
+reqwest-tracing = "0.3.0"
 ring = { version = "0.16", default-features = false, optional = true }
 schemars = { version = "0.8", features = ["bytes", "chrono", "url", "uuid1"] }
 serde = { version = "1", features = ["derive"] }

--- a/gusto/Cargo.toml
+++ b/gusto/Cargo.toml
@@ -32,7 +32,7 @@ reqwest = { version = "0.11.11", default-features = false, features = ["json", "
 reqwest-conditional-middleware = "0.1.0"
 reqwest-middleware = "0.1.5"
 reqwest-retry = "0.1.4"
-reqwest-tracing = { version = "0.3.0" }
+reqwest-tracing = "0.3.0"
 ring = { version = "0.16", default-features = false, optional = true }
 schemars = { version = "0.8", features = ["bytes", "chrono", "url", "uuid1"] }
 serde = { version = "1", features = ["derive"] }

--- a/gusto/Cargo.toml
+++ b/gusto/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 license = "MIT"
 
 [features]
-default = ["rustls-tls"]
+default = ["rustls-tls", "reqwest-tracing/opentelemetry_0_17"]
 # enable etag-based http_cache functionality
 httpcache = ["dirs"]
 native-tls = ["reqwest/default-tls", "openssl"]
@@ -32,7 +32,7 @@ reqwest = { version = "0.11.11", default-features = false, features = ["json", "
 reqwest-conditional-middleware = "0.1.0"
 reqwest-middleware = "0.1.5"
 reqwest-retry = "0.1.4"
-reqwest-tracing = { version = "0.3.0", features = ["opentelemetry_0_17"] }
+reqwest-tracing = { version = "0.3.0" }
 ring = { version = "0.16", default-features = false, optional = true }
 schemars = { version = "0.8", features = ["bytes", "chrono", "url", "uuid1"] }
 serde = { version = "1", features = ["derive"] }

--- a/mailchimp/Cargo.toml
+++ b/mailchimp/Cargo.toml
@@ -32,7 +32,7 @@ reqwest = { version = "0.11.11", default-features = false, features = ["json", "
 reqwest-conditional-middleware = "0.1.0"
 reqwest-middleware = "0.1.5"
 reqwest-retry = "0.1.4"
-reqwest-tracing = { version = "0.3.0" }
+reqwest-tracing = "0.3.0"
 ring = { version = "0.16", default-features = false, optional = true }
 schemars = { version = "0.8", features = ["bytes", "chrono", "url", "uuid1"] }
 serde = { version = "1", features = ["derive"] }

--- a/mailchimp/Cargo.toml
+++ b/mailchimp/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 license = "MIT"
 
 [features]
-default = ["rustls-tls"]
+default = ["rustls-tls", "reqwest-tracing/opentelemetry_0_17"]
 # enable etag-based http_cache functionality
 httpcache = ["dirs"]
 native-tls = ["reqwest/default-tls", "openssl"]
@@ -32,7 +32,7 @@ reqwest = { version = "0.11.11", default-features = false, features = ["json", "
 reqwest-conditional-middleware = "0.1.0"
 reqwest-middleware = "0.1.5"
 reqwest-retry = "0.1.4"
-reqwest-tracing = { version = "0.3.0", features = ["opentelemetry_0_17"] }
+reqwest-tracing = { version = "0.3.0" }
 ring = { version = "0.16", default-features = false, optional = true }
 schemars = { version = "0.8", features = ["bytes", "chrono", "url", "uuid1"] }
 serde = { version = "1", features = ["derive"] }

--- a/okta/Cargo.toml
+++ b/okta/Cargo.toml
@@ -32,7 +32,7 @@ reqwest = { version = "0.11.11", default-features = false, features = ["json", "
 reqwest-conditional-middleware = "0.1.0"
 reqwest-middleware = "0.1.5"
 reqwest-retry = "0.1.4"
-reqwest-tracing = { version = "0.3.0" }
+reqwest-tracing = "0.3.0"
 ring = { version = "0.16", default-features = false, optional = true }
 schemars = { version = "0.8", features = ["bytes", "chrono", "url", "uuid1"] }
 serde = { version = "1", features = ["derive"] }

--- a/okta/Cargo.toml
+++ b/okta/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 license = "MIT"
 
 [features]
-default = ["rustls-tls"]
+default = ["rustls-tls", "reqwest-tracing/opentelemetry_0_17"]
 # enable etag-based http_cache functionality
 httpcache = ["dirs"]
 native-tls = ["reqwest/default-tls", "openssl"]
@@ -32,7 +32,7 @@ reqwest = { version = "0.11.11", default-features = false, features = ["json", "
 reqwest-conditional-middleware = "0.1.0"
 reqwest-middleware = "0.1.5"
 reqwest-retry = "0.1.4"
-reqwest-tracing = { version = "0.3.0", features = ["opentelemetry_0_17"] }
+reqwest-tracing = { version = "0.3.0" }
 ring = { version = "0.16", default-features = false, optional = true }
 schemars = { version = "0.8", features = ["bytes", "chrono", "url", "uuid1"] }
 serde = { version = "1", features = ["derive"] }

--- a/ramp/Cargo.toml
+++ b/ramp/Cargo.toml
@@ -32,7 +32,7 @@ reqwest = { version = "0.11.11", default-features = false, features = ["json", "
 reqwest-conditional-middleware = "0.1.0"
 reqwest-middleware = "0.1.5"
 reqwest-retry = "0.1.4"
-reqwest-tracing = { version = "0.3.0" }
+reqwest-tracing = "0.3.0"
 ring = { version = "0.16", default-features = false, optional = true }
 schemars = { version = "0.8", features = ["bytes", "chrono", "url", "uuid1"] }
 serde = { version = "1", features = ["derive"] }

--- a/ramp/Cargo.toml
+++ b/ramp/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 license = "MIT"
 
 [features]
-default = ["rustls-tls"]
+default = ["rustls-tls", "reqwest-tracing/opentelemetry_0_17"]
 # enable etag-based http_cache functionality
 httpcache = ["dirs"]
 native-tls = ["reqwest/default-tls", "openssl"]
@@ -32,7 +32,7 @@ reqwest = { version = "0.11.11", default-features = false, features = ["json", "
 reqwest-conditional-middleware = "0.1.0"
 reqwest-middleware = "0.1.5"
 reqwest-retry = "0.1.4"
-reqwest-tracing = { version = "0.3.0", features = ["opentelemetry_0_17"] }
+reqwest-tracing = { version = "0.3.0" }
 ring = { version = "0.16", default-features = false, optional = true }
 schemars = { version = "0.8", features = ["bytes", "chrono", "url", "uuid1"] }
 serde = { version = "1", features = ["derive"] }

--- a/rev.ai/Cargo.toml
+++ b/rev.ai/Cargo.toml
@@ -32,7 +32,7 @@ reqwest = { version = "0.11.11", default-features = false, features = ["json", "
 reqwest-conditional-middleware = "0.1.0"
 reqwest-middleware = "0.1.5"
 reqwest-retry = "0.1.4"
-reqwest-tracing = { version = "0.3.0" }
+reqwest-tracing = "0.3.0"
 ring = { version = "0.16", default-features = false, optional = true }
 schemars = { version = "0.8", features = ["bytes", "chrono", "url", "uuid1"] }
 serde = { version = "1", features = ["derive"] }

--- a/rev.ai/Cargo.toml
+++ b/rev.ai/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 license = "MIT"
 
 [features]
-default = ["rustls-tls"]
+default = ["rustls-tls", "reqwest-tracing/opentelemetry_0_17"]
 # enable etag-based http_cache functionality
 httpcache = ["dirs"]
 native-tls = ["reqwest/default-tls", "openssl"]
@@ -32,7 +32,7 @@ reqwest = { version = "0.11.11", default-features = false, features = ["json", "
 reqwest-conditional-middleware = "0.1.0"
 reqwest-middleware = "0.1.5"
 reqwest-retry = "0.1.4"
-reqwest-tracing = { version = "0.3.0", features = ["opentelemetry_0_17"] }
+reqwest-tracing = { version = "0.3.0" }
 ring = { version = "0.16", default-features = false, optional = true }
 schemars = { version = "0.8", features = ["bytes", "chrono", "url", "uuid1"] }
 serde = { version = "1", features = ["derive"] }

--- a/sendgrid/Cargo.toml
+++ b/sendgrid/Cargo.toml
@@ -32,7 +32,7 @@ reqwest = { version = "0.11.11", default-features = false, features = ["json", "
 reqwest-conditional-middleware = "0.1.0"
 reqwest-middleware = "0.1.5"
 reqwest-retry = "0.1.4"
-reqwest-tracing = { version = "0.3.0" }
+reqwest-tracing = "0.3.0"
 ring = { version = "0.16", default-features = false, optional = true }
 schemars = { version = "0.8", features = ["bytes", "chrono", "url", "uuid1"] }
 serde = { version = "1", features = ["derive"] }

--- a/sendgrid/Cargo.toml
+++ b/sendgrid/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 license = "MIT"
 
 [features]
-default = ["rustls-tls"]
+default = ["rustls-tls", "reqwest-tracing/opentelemetry_0_17"]
 # enable etag-based http_cache functionality
 httpcache = ["dirs"]
 native-tls = ["reqwest/default-tls", "openssl"]
@@ -32,7 +32,7 @@ reqwest = { version = "0.11.11", default-features = false, features = ["json", "
 reqwest-conditional-middleware = "0.1.0"
 reqwest-middleware = "0.1.5"
 reqwest-retry = "0.1.4"
-reqwest-tracing = { version = "0.3.0", features = ["opentelemetry_0_17"] }
+reqwest-tracing = { version = "0.3.0" }
 ring = { version = "0.16", default-features = false, optional = true }
 schemars = { version = "0.8", features = ["bytes", "chrono", "url", "uuid1"] }
 serde = { version = "1", features = ["derive"] }

--- a/shipbob/Cargo.toml
+++ b/shipbob/Cargo.toml
@@ -32,7 +32,7 @@ reqwest = { version = "0.11.11", default-features = false, features = ["json", "
 reqwest-conditional-middleware = "0.1.0"
 reqwest-middleware = "0.1.5"
 reqwest-retry = "0.1.4"
-reqwest-tracing = { version = "0.3.0" }
+reqwest-tracing = "0.3.0"
 ring = { version = "0.16", default-features = false, optional = true }
 schemars = { version = "0.8", features = ["bytes", "chrono", "url", "uuid1"] }
 serde = { version = "1", features = ["derive"] }

--- a/shipbob/Cargo.toml
+++ b/shipbob/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 license = "MIT"
 
 [features]
-default = ["rustls-tls"]
+default = ["rustls-tls", "reqwest-tracing/opentelemetry_0_17"]
 # enable etag-based http_cache functionality
 httpcache = ["dirs"]
 native-tls = ["reqwest/default-tls", "openssl"]
@@ -32,7 +32,7 @@ reqwest = { version = "0.11.11", default-features = false, features = ["json", "
 reqwest-conditional-middleware = "0.1.0"
 reqwest-middleware = "0.1.5"
 reqwest-retry = "0.1.4"
-reqwest-tracing = { version = "0.3.0", features = ["opentelemetry_0_17"] }
+reqwest-tracing = { version = "0.3.0" }
 ring = { version = "0.16", default-features = false, optional = true }
 schemars = { version = "0.8", features = ["bytes", "chrono", "url", "uuid1"] }
 serde = { version = "1", features = ["derive"] }

--- a/shopify/Cargo.toml
+++ b/shopify/Cargo.toml
@@ -32,7 +32,7 @@ reqwest = { version = "0.11.11", default-features = false, features = ["json", "
 reqwest-conditional-middleware = "0.1.0"
 reqwest-middleware = "0.1.5"
 reqwest-retry = "0.1.4"
-reqwest-tracing = { version = "0.3.0" }
+reqwest-tracing = "0.3.0"
 ring = { version = "0.16", default-features = false, optional = true }
 schemars = { version = "0.8", features = ["bytes", "chrono", "url", "uuid1"] }
 serde = { version = "1", features = ["derive"] }

--- a/shopify/Cargo.toml
+++ b/shopify/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 license = "MIT"
 
 [features]
-default = ["rustls-tls"]
+default = ["rustls-tls", "reqwest-tracing/opentelemetry_0_17"]
 # enable etag-based http_cache functionality
 httpcache = ["dirs"]
 native-tls = ["reqwest/default-tls", "openssl"]
@@ -32,7 +32,7 @@ reqwest = { version = "0.11.11", default-features = false, features = ["json", "
 reqwest-conditional-middleware = "0.1.0"
 reqwest-middleware = "0.1.5"
 reqwest-retry = "0.1.4"
-reqwest-tracing = { version = "0.3.0", features = ["opentelemetry_0_17"] }
+reqwest-tracing = { version = "0.3.0" }
 ring = { version = "0.16", default-features = false, optional = true }
 schemars = { version = "0.8", features = ["bytes", "chrono", "url", "uuid1"] }
 serde = { version = "1", features = ["derive"] }

--- a/slack/Cargo.toml
+++ b/slack/Cargo.toml
@@ -32,7 +32,7 @@ reqwest = { version = "0.11.11", default-features = false, features = ["json", "
 reqwest-conditional-middleware = "0.1.0"
 reqwest-middleware = "0.1.5"
 reqwest-retry = "0.1.4"
-reqwest-tracing = { version = "0.3.0" }
+reqwest-tracing = "0.3.0"
 ring = { version = "0.16", default-features = false, optional = true }
 schemars = { version = "0.8", features = ["bytes", "chrono", "url", "uuid1"] }
 serde = { version = "1", features = ["derive"] }

--- a/slack/Cargo.toml
+++ b/slack/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 license = "MIT"
 
 [features]
-default = ["rustls-tls"]
+default = ["rustls-tls", "reqwest-tracing/opentelemetry_0_17"]
 # enable etag-based http_cache functionality
 httpcache = ["dirs"]
 native-tls = ["reqwest/default-tls", "openssl"]
@@ -32,7 +32,7 @@ reqwest = { version = "0.11.11", default-features = false, features = ["json", "
 reqwest-conditional-middleware = "0.1.0"
 reqwest-middleware = "0.1.5"
 reqwest-retry = "0.1.4"
-reqwest-tracing = { version = "0.3.0", features = ["opentelemetry_0_17"] }
+reqwest-tracing = { version = "0.3.0" }
 ring = { version = "0.16", default-features = false, optional = true }
 schemars = { version = "0.8", features = ["bytes", "chrono", "url", "uuid1"] }
 serde = { version = "1", features = ["derive"] }

--- a/stripe/Cargo.toml
+++ b/stripe/Cargo.toml
@@ -32,7 +32,7 @@ reqwest = { version = "0.11.11", default-features = false, features = ["json", "
 reqwest-conditional-middleware = "0.1.0"
 reqwest-middleware = "0.1.5"
 reqwest-retry = "0.1.4"
-reqwest-tracing = { version = "0.3.0" }
+reqwest-tracing = "0.3.0"
 ring = { version = "0.16", default-features = false, optional = true }
 schemars = { version = "0.8", features = ["bytes", "chrono", "url", "uuid1"] }
 serde = { version = "1", features = ["derive"] }

--- a/stripe/Cargo.toml
+++ b/stripe/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 license = "MIT"
 
 [features]
-default = ["rustls-tls"]
+default = ["rustls-tls", "reqwest-tracing/opentelemetry_0_17"]
 # enable etag-based http_cache functionality
 httpcache = ["dirs"]
 native-tls = ["reqwest/default-tls", "openssl"]
@@ -32,7 +32,7 @@ reqwest = { version = "0.11.11", default-features = false, features = ["json", "
 reqwest-conditional-middleware = "0.1.0"
 reqwest-middleware = "0.1.5"
 reqwest-retry = "0.1.4"
-reqwest-tracing = { version = "0.3.0", features = ["opentelemetry_0_17"] }
+reqwest-tracing = { version = "0.3.0" }
 ring = { version = "0.16", default-features = false, optional = true }
 schemars = { version = "0.8", features = ["bytes", "chrono", "url", "uuid1"] }
 serde = { version = "1", features = ["derive"] }

--- a/tripactions/Cargo.toml
+++ b/tripactions/Cargo.toml
@@ -32,7 +32,7 @@ reqwest = { version = "0.11.11", default-features = false, features = ["json", "
 reqwest-conditional-middleware = "0.1.0"
 reqwest-middleware = "0.1.5"
 reqwest-retry = "0.1.4"
-reqwest-tracing = { version = "0.3.0" }
+reqwest-tracing = "0.3.0"
 ring = { version = "0.16", default-features = false, optional = true }
 schemars = { version = "0.8", features = ["bytes", "chrono", "url", "uuid1"] }
 serde = { version = "1", features = ["derive"] }

--- a/tripactions/Cargo.toml
+++ b/tripactions/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 license = "MIT"
 
 [features]
-default = ["rustls-tls"]
+default = ["rustls-tls", "reqwest-tracing/opentelemetry_0_17"]
 # enable etag-based http_cache functionality
 httpcache = ["dirs"]
 native-tls = ["reqwest/default-tls", "openssl"]
@@ -32,7 +32,7 @@ reqwest = { version = "0.11.11", default-features = false, features = ["json", "
 reqwest-conditional-middleware = "0.1.0"
 reqwest-middleware = "0.1.5"
 reqwest-retry = "0.1.4"
-reqwest-tracing = { version = "0.3.0", features = ["opentelemetry_0_17"] }
+reqwest-tracing = { version = "0.3.0" }
 ring = { version = "0.16", default-features = false, optional = true }
 schemars = { version = "0.8", features = ["bytes", "chrono", "url", "uuid1"] }
 serde = { version = "1", features = ["derive"] }

--- a/zoom/Cargo.toml
+++ b/zoom/Cargo.toml
@@ -32,7 +32,7 @@ reqwest = { version = "0.11.11", default-features = false, features = ["json", "
 reqwest-conditional-middleware = "0.1.0"
 reqwest-middleware = "0.1.5"
 reqwest-retry = "0.1.4"
-reqwest-tracing = { version = "0.3.0" }
+reqwest-tracing = "0.3.0"
 ring = { version = "0.16", default-features = false, optional = true }
 schemars = { version = "0.8", features = ["bytes", "chrono", "url", "uuid1"] }
 serde = { version = "1", features = ["derive"] }

--- a/zoom/Cargo.toml
+++ b/zoom/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 license = "MIT"
 
 [features]
-default = ["rustls-tls"]
+default = ["rustls-tls", "reqwest-tracing/opentelemetry_0_17"]
 # enable etag-based http_cache functionality
 httpcache = ["dirs"]
 native-tls = ["reqwest/default-tls", "openssl"]
@@ -32,7 +32,7 @@ reqwest = { version = "0.11.11", default-features = false, features = ["json", "
 reqwest-conditional-middleware = "0.1.0"
 reqwest-middleware = "0.1.5"
 reqwest-retry = "0.1.4"
-reqwest-tracing = { version = "0.3.0", features = ["opentelemetry_0_17"] }
+reqwest-tracing = { version = "0.3.0" }
 ring = { version = "0.16", default-features = false, optional = true }
 schemars = { version = "0.8", features = ["bytes", "chrono", "url", "uuid1"] }
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
I don't know if this is really the best solution. Would it be better to just use the default features of reqwest-tracing and let the consuming program enable the opentelemetry feature if desired?

The generated API clients have some code to create an HTTP client and they attach reqwest-tracing so the requests are observable. In my project, we are using a newer version of opentelemetry and providing our own HTTP clients. For octorust 0.1.x this worked fine because we were compiling two versions of reqwest-tracing and two versions of opentelemetry and then at runtime we would only use the newer version of the middleware. However, now that octorust uses the same reqwest-tracing we get a compile error because there are multiple opentelemetry_* features enabled at the same time in the same reqwest-tracing.