### PR TITLE
disable chrono default-features

### DIFF
--- a/docusign/Cargo.toml
+++ b/docusign/Cargo.toml
@@ -18,7 +18,7 @@ rustls-tls = ["reqwest/rustls-tls", "ring", "pem"]
 [dependencies]
 anyhow = "1"
 async-recursion = "^1.0"
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4", default-features = false, features = ["serde"] }
 dirs = { version = "^3.0.2", optional = true }
 http = "^0.2.4"
 hyperx = "1"

--- a/generator/src/main.rs
+++ b/generator/src/main.rs
@@ -3241,7 +3241,7 @@ rustls-tls = ["reqwest/rustls-tls", "ring", "pem"]
 [dependencies]
 anyhow = "1"
 async-recursion = "^1.0"
-chrono = {{ version = "0.4", features = ["serde"] }}
+chrono = {{ version = "0.4", default-features = false, features = ["serde"] }}
 dirs = {{ version = "^3.0.2", optional = true }}
 http = "^0.2.4"
 hyperx = "1"

--- a/giphy/Cargo.toml
+++ b/giphy/Cargo.toml
@@ -18,7 +18,7 @@ rustls-tls = ["reqwest/rustls-tls", "ring", "pem"]
 [dependencies]
 anyhow = "1"
 async-recursion = "^1.0"
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4", default-features = false, features = ["serde"] }
 dirs = { version = "^3.0.2", optional = true }
 http = "^0.2.4"
 hyperx = "1"

--- a/github/Cargo.toml
+++ b/github/Cargo.toml
@@ -18,7 +18,7 @@ rustls-tls = ["reqwest/rustls-tls", "ring", "pem"]
 [dependencies]
 anyhow = "1"
 async-recursion = "^1.0"
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4", default-features = false, features = ["serde"] }
 dirs = { version = "^3.0.2", optional = true }
 http = "^0.2.4"
 hyperx = "1"

--- a/google/admin/Cargo.toml
+++ b/google/admin/Cargo.toml
@@ -18,7 +18,7 @@ rustls-tls = ["reqwest/rustls-tls", "ring", "pem"]
 [dependencies]
 anyhow = "1"
 async-recursion = "^1.0"
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4", default-features = false, features = ["serde"] }
 dirs = { version = "^3.0.2", optional = true }
 http = "^0.2.4"
 hyperx = "1"

--- a/google/calendar/Cargo.toml
+++ b/google/calendar/Cargo.toml
@@ -18,7 +18,7 @@ rustls-tls = ["reqwest/rustls-tls", "ring", "pem"]
 [dependencies]
 anyhow = "1"
 async-recursion = "^1.0"
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4", default-features = false, features = ["serde"] }
 dirs = { version = "^3.0.2", optional = true }
 http = "^0.2.4"
 hyperx = "1"

--- a/google/cloud-resource-manager/Cargo.toml
+++ b/google/cloud-resource-manager/Cargo.toml
@@ -18,7 +18,7 @@ rustls-tls = ["reqwest/rustls-tls", "ring", "pem"]
 [dependencies]
 anyhow = "1"
 async-recursion = "^1.0"
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4", default-features = false, features = ["serde"] }
 dirs = { version = "^3.0.2", optional = true }
 http = "^0.2.4"
 hyperx = "1"

--- a/google/drive/Cargo.toml
+++ b/google/drive/Cargo.toml
@@ -18,7 +18,7 @@ rustls-tls = ["reqwest/rustls-tls", "ring", "pem"]
 [dependencies]
 anyhow = "1"
 async-recursion = "^1.0"
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4", default-features = false, features = ["serde"] }
 dirs = { version = "^3.0.2", optional = true }
 http = "^0.2.4"
 hyperx = "1"

--- a/google/groups-settings/Cargo.toml
+++ b/google/groups-settings/Cargo.toml
@@ -18,7 +18,7 @@ rustls-tls = ["reqwest/rustls-tls", "ring", "pem"]
 [dependencies]
 anyhow = "1"
 async-recursion = "^1.0"
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4", default-features = false, features = ["serde"] }
 dirs = { version = "^3.0.2", optional = true }
 http = "^0.2.4"
 hyperx = "1"

--- a/google/sheets/Cargo.toml
+++ b/google/sheets/Cargo.toml
@@ -18,7 +18,7 @@ rustls-tls = ["reqwest/rustls-tls", "ring", "pem"]
 [dependencies]
 anyhow = "1"
 async-recursion = "^1.0"
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4", default-features = false, features = ["serde"] }
 dirs = { version = "^3.0.2", optional = true }
 http = "^0.2.4"
 hyperx = "1"

--- a/gusto/Cargo.toml
+++ b/gusto/Cargo.toml
@@ -18,7 +18,7 @@ rustls-tls = ["reqwest/rustls-tls", "ring", "pem"]
 [dependencies]
 anyhow = "1"
 async-recursion = "^1.0"
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4", default-features = false, features = ["serde"] }
 dirs = { version = "^3.0.2", optional = true }
 http = "^0.2.4"
 hyperx = "1"

--- a/mailchimp/Cargo.toml
+++ b/mailchimp/Cargo.toml
@@ -18,7 +18,7 @@ rustls-tls = ["reqwest/rustls-tls", "ring", "pem"]
 [dependencies]
 anyhow = "1"
 async-recursion = "^1.0"
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4", default-features = false, features = ["serde"] }
 dirs = { version = "^3.0.2", optional = true }
 http = "^0.2.4"
 hyperx = "1"

--- a/okta/Cargo.toml
+++ b/okta/Cargo.toml
@@ -18,7 +18,7 @@ rustls-tls = ["reqwest/rustls-tls", "ring", "pem"]
 [dependencies]
 anyhow = "1"
 async-recursion = "^1.0"
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4", default-features = false, features = ["serde"] }
 dirs = { version = "^3.0.2", optional = true }
 http = "^0.2.4"
 hyperx = "1"

--- a/ramp/Cargo.toml
+++ b/ramp/Cargo.toml
@@ -18,7 +18,7 @@ rustls-tls = ["reqwest/rustls-tls", "ring", "pem"]
 [dependencies]
 anyhow = "1"
 async-recursion = "^1.0"
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4", default-features = false, features = ["serde"] }
 dirs = { version = "^3.0.2", optional = true }
 http = "^0.2.4"
 hyperx = "1"

--- a/rev.ai/Cargo.toml
+++ b/rev.ai/Cargo.toml
@@ -18,7 +18,7 @@ rustls-tls = ["reqwest/rustls-tls", "ring", "pem"]
 [dependencies]
 anyhow = "1"
 async-recursion = "^1.0"
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4", default-features = false, features = ["serde"] }
 dirs = { version = "^3.0.2", optional = true }
 http = "^0.2.4"
 hyperx = "1"

--- a/sendgrid/Cargo.toml
+++ b/sendgrid/Cargo.toml
@@ -18,7 +18,7 @@ rustls-tls = ["reqwest/rustls-tls", "ring", "pem"]
 [dependencies]
 anyhow = "1"
 async-recursion = "^1.0"
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4", default-features = false, features = ["serde"] }
 dirs = { version = "^3.0.2", optional = true }
 http = "^0.2.4"
 hyperx = "1"

--- a/shipbob/Cargo.toml
+++ b/shipbob/Cargo.toml
@@ -18,7 +18,7 @@ rustls-tls = ["reqwest/rustls-tls", "ring", "pem"]
 [dependencies]
 anyhow = "1"
 async-recursion = "^1.0"
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4", default-features = false, features = ["serde"] }
 dirs = { version = "^3.0.2", optional = true }
 http = "^0.2.4"
 hyperx = "1"

--- a/shopify/Cargo.toml
+++ b/shopify/Cargo.toml
@@ -18,7 +18,7 @@ rustls-tls = ["reqwest/rustls-tls", "ring", "pem"]
 [dependencies]
 anyhow = "1"
 async-recursion = "^1.0"
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4", default-features = false, features = ["serde"] }
 dirs = { version = "^3.0.2", optional = true }
 http = "^0.2.4"
 hyperx = "1"

--- a/slack/Cargo.toml
+++ b/slack/Cargo.toml
@@ -18,7 +18,7 @@ rustls-tls = ["reqwest/rustls-tls", "ring", "pem"]
 [dependencies]
 anyhow = "1"
 async-recursion = "^1.0"
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4", default-features = false, features = ["serde"] }
 dirs = { version = "^3.0.2", optional = true }
 http = "^0.2.4"
 hyperx = "1"

--- a/stripe/Cargo.toml
+++ b/stripe/Cargo.toml
@@ -18,7 +18,7 @@ rustls-tls = ["reqwest/rustls-tls", "ring", "pem"]
 [dependencies]
 anyhow = "1"
 async-recursion = "^1.0"
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4", default-features = false, features = ["serde"] }
 dirs = { version = "^3.0.2", optional = true }
 http = "^0.2.4"
 hyperx = "1"

--- a/tripactions/Cargo.toml
+++ b/tripactions/Cargo.toml
@@ -18,7 +18,7 @@ rustls-tls = ["reqwest/rustls-tls", "ring", "pem"]
 [dependencies]
 anyhow = "1"
 async-recursion = "^1.0"
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4", default-features = false, features = ["serde"] }
 dirs = { version = "^3.0.2", optional = true }
 http = "^0.2.4"
 hyperx = "1"

--- a/zoom/Cargo.toml
+++ b/zoom/Cargo.toml
@@ -18,7 +18,7 @@ rustls-tls = ["reqwest/rustls-tls", "ring", "pem"]
 [dependencies]
 anyhow = "1"
 async-recursion = "^1.0"
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4", default-features = false, features = ["serde"] }
 dirs = { version = "^3.0.2", optional = true }
 http = "^0.2.4"
 hyperx = "1"


### PR DESCRIPTION
chrono 0.4, for legacy reasons, has a dependency on time 0.1. time 0.1 has the potential for [CVE-2020-26235](https://nvd.nist.gov/vuln/detail/CVE-2020-26235).

This dependency can be avoided by turning off the default features. The build succeeds after changing this and disabling the Google clients (which use another library that brings in the default features I'm trying to avoid) so it looks like the other features were not being used directly here.