### PR TITLE
[github] Use Option<&str> instead of Option<DateTime> for `list_workf…

### DIFF
--- a/generator/src/functions.rs
+++ b/generator/src/functions.rs
@@ -138,7 +138,7 @@ pub fn generate_files(
                 content
             };
 
-            let docs = get_fn_docs(o, m, p, parameters, ts)?;
+            let docs = get_fn_docs(proper_name, o, m, p, parameters, ts)?;
 
             let mut bounds: Vec<String> = Vec::new();
 
@@ -727,7 +727,7 @@ fn get_fn_params(
         let nam = &to_snake_case(&parameter_data.name);
 
         if !fn_params.contains(nam) && !fn_params.contains(&format!("{}_", nam)) {
-            let typ = parameter_data.render_type(&param_name, ts)?;
+            let typ = parameter_data.render_type(proper_name, &param_name, ts)?;
             if nam == "ref"
                 || nam == "type"
                 || nam == "foo"
@@ -1143,6 +1143,7 @@ fn get_fn_inner(
 }
 
 fn get_fn_docs(
+    proper_name: &str,
     o: &openapiv3::Operation,
     m: &str,
     p: &str,
@@ -1215,7 +1216,7 @@ fn get_fn_docs(
         }
 
         let nam = &to_snake_case(&clean_name(&parameter_data.name));
-        let typ = parameter_data.render_type(&param_name, ts)?;
+        let typ = parameter_data.render_type(proper_name, &param_name, ts)?;
 
         if nam == "ref"
             || nam == "type"

--- a/generator/src/template.rs
+++ b/generator/src/template.rs
@@ -62,6 +62,11 @@ impl Template {
                         r#"if {} {{ query_args.push(("{}".to_string(), {}.to_string())); }}"#,
                         nam, prop, nam
                     ));
+                } else if value == "Option<&str>" {
+                    a(&format!(
+                        r#"if let Some(s) = {} {{ if !s.is_empty() {{ query_args.push(("{}".to_string(), s.to_string())); }} }}"#,
+                        nam, prop
+                    ));
                 } else if value == "&str" {
                     a(&format!(
                         r#"if !{}.is_empty() {{ query_args.push(("{}".to_string(), {}.to_string())); }}"#,


### PR DESCRIPTION
…low_runs`'s `created` parameter.

The issue is described in more details in https://github.com/github/rest-api-description/issues/2088

For now, this change will treat the created parameter as an optional str, which it would probably do if the parameter had a custom format defined.
Alternatively, one oculd try to implement a proper datetime rnage that follows the [Query for
dates](https://docs.github.com/en/search-github/getting-started-with-searching-on-github/understanding-the-search-syntax#query-for-dates) format, but this is maybe more work than one would benefit by implementing the search formating on the user side.