### PR TITLE
[github] add default derive for MinimalRepository and WorkflowRun

### DIFF
--- a/generator/src/types.rs
+++ b/generator/src/types.rs
@@ -96,6 +96,9 @@ pub fn generate_types(ts: &mut TypeSpace, proper_name: &str) -> Result<String> {
                         || sn == "DescriptionlessJobOptionsDataType"
                         || sn == "SubmitJobOptions"
                         || sn == "SubmitJobOptionsData"
+                        || sn == "MinimalRepository"
+                        || sn == "WorkflowRun"
+                        || sn == "CheckAnnotation"
                     {
                         a(
                             "#[derive(Serialize, Default, Deserialize, PartialEq, Debug, Clone, \

--- a/github/src/types.rs
+++ b/github/src/types.rs
@@ -6123,7 +6123,7 @@ pub struct License {
 }
 
 /// Minimal Repository
-#[derive(Serialize, Deserialize, PartialEq, Debug, Clone, JsonSchema)]
+#[derive(Serialize, Default, Deserialize, PartialEq, Debug, Clone, JsonSchema)]
 pub struct MinimalRepository {
     #[serde(
         default,
@@ -10850,7 +10850,7 @@ pub struct SimpleCommit {
 }
 
 /// An invocation of a workflow
-#[derive(Serialize, Deserialize, PartialEq, Debug, Clone, JsonSchema)]
+#[derive(Serialize, Default, Deserialize, PartialEq, Debug, Clone, JsonSchema)]
 pub struct WorkflowRun {
     #[serde(
         default,
@@ -12998,7 +12998,7 @@ pub struct CheckRun {
 }
 
 /// Check Annotation
-#[derive(Serialize, Deserialize, PartialEq, Debug, Clone, JsonSchema)]
+#[derive(Serialize, Default, Deserialize, PartialEq, Debug, Clone, JsonSchema)]
 pub struct CheckAnnotation {
     #[serde(
         default,


### PR DESCRIPTION
When instanciating those in test, the number of fields that needs to be declared is overwhelming. When dealing with test cases, in many cases, only a few fields really matter and having something to populate defaults avoid lots of boiler plate.