### PR TITLE
set github jwk iat in the past as per docs

### DIFF
--- a/github/src/auth.rs
+++ b/github/src/auth.rs
@@ -143,7 +143,7 @@ impl ExpiringJWTCredential {
 
         let payload = JWTCredentialClaim {
             // GitHub recommends specifying this as 60 seconds in the past to avoid problems with clock drift.
-            iat: now.as_secs() - 60,
+            iat: now.as_secs().saturating_sub(60),
             exp: expires.as_secs(),
             iss: app_id,
         };

--- a/github/src/auth.rs
+++ b/github/src/auth.rs
@@ -142,7 +142,8 @@ impl ExpiringJWTCredential {
         let expires = now + MAX_JWT_TOKEN_LIFE;
 
         let payload = JWTCredentialClaim {
-            iat: now.as_secs(),
+            // GitHub recommends specifying this as 60 seconds in the past to avoid problems with clock drift.
+            iat: now.as_secs() - 60,
             exp: expires.as_secs(),
             iss: app_id,
         };


### PR DESCRIPTION
GitHub's documentation about authenticating using JWT recommends to [set `iat` 60s into the past](https://docs.github.com/en/developers/apps/building-github-apps/authenticating-with-github-apps#generating-a-json-web-token-jwt).