### PR TITLE
Fix installation types

### DIFF
--- a/github/examples/get_repo_in_org.rs
+++ b/github/examples/get_repo_in_org.rs
@@ -10,10 +10,10 @@ use octorust::{
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let app_id_str = env::var("GH_APP_ID").unwrap();
-    let app_id = app_id_str.parse::<u64>().unwrap();
+    let app_id = app_id_str.parse::<i64>().unwrap();
 
     let app_installation_id_str = env::var("GH_INSTALLATION_ID").unwrap();
-    let app_installation_id = app_installation_id_str.parse::<u64>().unwrap();
+    let app_installation_id = app_installation_id_str.parse::<i64>().unwrap();
 
     let encoded_private_key = env::var("GH_PRIVATE_KEY").unwrap();
     let private_key = base64::decode(encoded_private_key).unwrap();

--- a/github/examples/list_pulls_for_repo.rs
+++ b/github/examples/list_pulls_for_repo.rs
@@ -11,10 +11,10 @@ use octorust::{
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let app_id_str = env::var("GH_APP_ID").unwrap();
-    let app_id = app_id_str.parse::<u64>().unwrap();
+    let app_id = app_id_str.parse::<i64>().unwrap();
 
     let app_installation_id_str = env::var("GH_INSTALLATION_ID").unwrap();
-    let app_installation_id = app_installation_id_str.parse::<u64>().unwrap();
+    let app_installation_id = app_installation_id_str.parse::<i64>().unwrap();
 
     let encoded_private_key = env::var("GH_PRIVATE_KEY").unwrap();
     let private_key = base64::decode(encoded_private_key).unwrap();

--- a/github/examples/list_repos_for_org.rs
+++ b/github/examples/list_repos_for_org.rs
@@ -11,10 +11,10 @@ use octorust::{
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let app_id_str = env::var("GH_APP_ID").unwrap();
-    let app_id = app_id_str.parse::<u64>().unwrap();
+    let app_id = app_id_str.parse::<i64>().unwrap();
 
     let app_installation_id_str = env::var("GH_INSTALLATION_ID").unwrap();
-    let app_installation_id = app_installation_id_str.parse::<u64>().unwrap();
+    let app_installation_id = app_installation_id_str.parse::<i64>().unwrap();
 
     let encoded_private_key = env::var("GH_PRIVATE_KEY").unwrap();
     let private_key = base64::decode(encoded_private_key).unwrap();

--- a/github/src/auth.rs
+++ b/github/src/auth.rs
@@ -83,7 +83,7 @@ impl fmt::Debug for Credentials {
 /// even though JWTCredentials is not mutable.
 #[derive(Clone)]
 pub struct JWTCredentials {
-    pub app_id: u64,
+    pub app_id: i64,
     /// DER RSA key. Generate with
     /// `openssl rsa -in private_rsa_key.pem -outform DER -out private_rsa_key.der`
     pub private_key: Vec<u8>,
@@ -91,7 +91,7 @@ pub struct JWTCredentials {
 }
 
 impl JWTCredentials {
-    pub fn new(app_id: u64, private_key: Vec<u8>) -> Result<JWTCredentials> {
+    pub fn new(app_id: i64, private_key: Vec<u8>) -> Result<JWTCredentials> {
         let creds = ExpiringJWTCredential::calculate(app_id, &private_key)?;
 
         Ok(JWTCredentials {
@@ -129,11 +129,11 @@ struct ExpiringJWTCredential {
 struct JWTCredentialClaim {
     iat: u64,
     exp: u64,
-    iss: u64,
+    iss: i64,
 }
 
 impl ExpiringJWTCredential {
-    fn calculate(app_id: u64, private_key: &[u8]) -> Result<ExpiringJWTCredential> {
+    fn calculate(app_id: i64, private_key: &[u8]) -> Result<ExpiringJWTCredential> {
         // SystemTime can go backwards, Instant can't, so always use
         // Instant for ensuring regular cycling.
         let created_at = tokio::time::Instant::now();
@@ -195,13 +195,13 @@ impl ExpiringInstallationToken {
 /// The RwLock<Option> access key is for interior mutability.
 #[derive(Debug, Clone)]
 pub struct InstallationTokenGenerator {
-    pub installation_id: u64,
+    pub installation_id: i64,
     pub jwt_credential: Box<Credentials>,
     pub(crate) access_key: Arc<RwLock<Option<ExpiringInstallationToken>>>,
 }
 
 impl InstallationTokenGenerator {
-    pub fn new(installation_id: u64, creds: JWTCredentials) -> InstallationTokenGenerator {
+    pub fn new(installation_id: i64, creds: JWTCredentials) -> InstallationTokenGenerator {
         InstallationTokenGenerator {
             installation_id,
             jwt_credential: Box::new(Credentials::JWT(creds)),
@@ -236,14 +236,14 @@ mod tests {
     use rsa::{pkcs1::EncodeRsaPrivateKey, RsaPrivateKey};
     use std::time::Duration;
 
-    fn app_id() -> u64 {
+    fn app_id() -> i64 {
         let mut rng = rand::thread_rng();
-        rng.next_u64()
+        rng.next_u32() as i64
     }
 
-    fn installation_id() -> u64 {
+    fn installation_id() -> i64 {
         let mut rng = rand::thread_rng();
-        rng.next_u64()
+        rng.next_u32() as i64
     }
 
     fn private_key() -> Vec<u8> {

--- a/github/tests/tests.rs
+++ b/github/tests/tests.rs
@@ -13,14 +13,14 @@ use octorust::{
     Client,
 };
 
-fn app_id() -> u64 {
+fn app_id() -> i64 {
     let mut rng = rand::thread_rng();
-    rng.next_u64()
+    rng.next_u32() as i64
 }
 
-fn installation_id() -> u64 {
+fn installation_id() -> i64 {
     let mut rng = rand::thread_rng();
-    rng.next_u64()
+    rng.next_u32() as i64
 }
 
 fn private_key() -> Vec<u8> {
@@ -34,7 +34,7 @@ fn private_key() -> Vec<u8> {
 }
 
 #[tokio::test]
-async fn refreshes_installation_token_once() {
+async fn test_refreshes_installation_token_once() {
     let installation_id = installation_id();
 
     let server = MockServer::start().await;


### PR DESCRIPTION
* Update `app_id` and `installation_id` from `u64` to `i64`

The spec defines these as integers which causes them to be generated as `i64`. Previously passing a `u64` would result in possible overflow.