### PR TITLE
[github] Specialized errors

### DIFF
--- a/generator/src/client.rs
+++ b/generator/src/client.rs
@@ -5,7 +5,38 @@ use crate::struct_name;
 /*
  * Declare the client object:
  */
-pub const GITHUB_TEMPLATE: &str = r#"/// Entrypoint for interacting with the API client.
+pub const GITHUB_TEMPLATE: &str = r#"/// Errors returned by the client
+#[derive(Debug, Error)]
+pub enum ClientError {
+    /// Ratelimited
+    #[error("Rate limited for the next {duration} seconds")]
+    RateLimited{
+        duration: u64,
+    },
+    /// URL Parsing Error
+    #[error(transparent)]
+    UrlParserError(#[from] url::ParseError),
+    /// Serde JSON parsing error
+    #[error(transparent)]
+    SerdeJsonError(#[from] serde_json::Error),
+    /// Errors returned by reqwest
+    #[error(transparent)]
+    ReqwestError(#[from] reqwest::Error),
+    /// Errors returned by reqwest middleware
+    #[error(transparent)]
+    ReqwestMiddleWareError(#[from] reqwest_middleware::Error),
+    /// Generic HTTP Error
+    #[error("HTTP Error. Code: {status}, message: {error}")]
+    HttpError {
+        status: http::StatusCode,
+        error: String,
+    },
+    /// Generic errors returned by the API.
+    #[error(transparent)]
+    GenericError(#[from] anyhow::Error),
+}
+
+/// Entrypoint for interacting with the API client.
 #[derive(Clone)]
 pub struct Client {
     host: String,
@@ -18,7 +49,7 @@ pub struct Client {
 }
 
 impl Client {
-    pub fn new<A, C>(agent: A, credentials: C) -> Result<Self>
+    pub fn new<A, C>(agent: A, credentials: C) -> ClientResult<Self>
     where
         A: Into<String>,
         C: Into<Option<crate::auth::Credentials>>,
@@ -140,25 +171,23 @@ impl Client {
         &self,
         uri: &str,
         authentication: crate::auth::AuthenticationConstraint,
-    ) -> Result<(reqwest::Url, Option<String>)> {
-        let parsed_url = uri.parse::<reqwest::Url>();
+    ) -> ClientResult<(reqwest::Url, Option<String>)> {
+        let mut parsed_url = uri.parse::<reqwest::Url>()?;
 
         match self.credentials(authentication) {
-            Some(&crate::auth::Credentials::Client(ref id, ref secret)) => parsed_url
-                .map(|mut u| {
-                    u.query_pairs_mut()
+            Some(&crate::auth::Credentials::Client(ref id, ref secret)) => {
+                parsed_url.query_pairs_mut()
                         .append_pair("client_id", id)
                         .append_pair("client_secret", secret);
-                    (u, None)
-                })
-                .map_err(Error::from),
+                Ok((parsed_url, None))
+            },
             Some(&crate::auth::Credentials::Token(ref token)) => {
                 let auth = format!("token {}", token);
-                parsed_url.map(|u| (u, Some(auth))).map_err(Error::from)
+                Ok((parsed_url, Some(auth)))
             }
             Some(&crate::auth::Credentials::JWT(ref jwt)) => {
                 let auth = format!("Bearer {}", jwt.token());
-                parsed_url.map(|u| (u, Some(auth))).map_err(Error::from)
+                Ok((parsed_url, Some(auth)))
             }
             Some(&crate::auth::Credentials::InstallationToken(ref apptoken)) => {
                 let token = if let Some(token) = apptoken.token().await {
@@ -190,9 +219,9 @@ impl Client {
                     }
                 };
                 let auth = format!("token {}", token);
-                parsed_url.map(|u| (u, Some(auth))).map_err(Error::from)
+                Ok((parsed_url, Some(auth)))
             }
-            None => parsed_url.map(|u| (u, None)).map_err(Error::from),
+            None => Ok((parsed_url, None)),
         }
     }
 
@@ -203,7 +232,7 @@ impl Client {
         message: Message,
         media_type: crate::utils::MediaType,
         authentication: crate::auth::AuthenticationConstraint,
-    ) -> Result<(Option<crate::utils::NextLink>, Out)>
+    ) -> ClientResult<(Option<crate::utils::NextLink>, Out)>
     where
         Out: serde::de::DeserializeOwned + 'static + Send,
     {
@@ -287,11 +316,11 @@ impl Client {
             }
 
             let parsed_response = if status == http::StatusCode::NO_CONTENT || std::any::TypeId::of::<Out>() == std::any::TypeId::of::<()>(){
-                serde_json::from_str("null")
+                serde_json::from_str("null")?
             } else {
-                serde_json::from_slice::<Out>(&response_body)
+                serde_json::from_slice::<Out>(&response_body)?
             };
-            parsed_response.map(|out| (next_link, out)).map_err(Error::from)
+            Ok((next_link, parsed_response))
         } else if status == http::StatusCode::NOT_MODIFIED {
                 // only supported case is when client provides if-none-match
                 // header when cargo builds with --cfg feature="httpcache"
@@ -317,13 +346,13 @@ impl Client {
                         .duration_since(std::time::UNIX_EPOCH)
                         .unwrap()
                         .as_secs();
-                    anyhow!("rate limit exceeded, will reset in {} seconds", u64::from(reset).saturating_sub(now))
+                    ClientError::RateLimited{duration: u64::from(reset).saturating_sub(now)}
                 },
                 _ => {
                     if response_body.is_empty() {
-                        anyhow!("code: {}, empty response", status)
+                        ClientError::HttpError{status: status, error: "empty response".into()}
                     } else {
-                        anyhow!("code: {}, error: {:?}", status, String::from_utf8_lossy(&response_body),)
+                        ClientError::HttpError{status: status, error: String::from_utf8_lossy(&response_body).into()}
                     }
                 }
             };
@@ -338,7 +367,7 @@ impl Client {
         message: Message,
         media_type: crate::utils::MediaType,
         authentication: crate::auth::AuthenticationConstraint,
-    ) -> Result<D>
+    ) -> ClientResult<D>
     where
         D: serde::de::DeserializeOwned + 'static + Send,
     {
@@ -346,14 +375,14 @@ impl Client {
         Ok(r)
     }
 
-    async fn get<D>(&self, uri: &str, message: Message) -> Result<D>
+    async fn get<D>(&self, uri: &str, message: Message) -> ClientResult<D>
     where
         D: serde::de::DeserializeOwned + 'static + Send,
     {
         self.get_media(uri, crate::utils::MediaType::Json, message).await
     }
 
-    async fn get_media<D>(&self, uri: &str, media: crate::utils::MediaType, message: Message) -> Result<D>
+    async fn get_media<D>(&self, uri: &str, media: crate::utils::MediaType, message: Message) -> ClientResult<D>
     where
         D: serde::de::DeserializeOwned + 'static + Send,
     {
@@ -366,14 +395,14 @@ impl Client {
         ).await
     }
 
-    async fn get_all_pages<D>(&self, uri: &str,  _message: Message) -> Result<Vec<D>>
+    async fn get_all_pages<D>(&self, uri: &str,  _message: Message) -> ClientResult<Vec<D>>
     where
         D: serde::de::DeserializeOwned + 'static + Send,
     {
         self.unfold(uri).await
     }
 
-    async fn get_pages<D>(&self, uri: &str) -> Result<(Option<crate::utils::NextLink>, Vec<D>)>
+    async fn get_pages<D>(&self, uri: &str) -> ClientResult<(Option<crate::utils::NextLink>, Vec<D>)>
     where
         D: serde::de::DeserializeOwned + 'static + Send,
     {
@@ -386,7 +415,7 @@ impl Client {
         ).await
     }
 
-    async fn get_pages_url<D>(&self, url: &reqwest::Url) -> Result<(Option<crate::utils::NextLink>, Vec<D>)>
+    async fn get_pages_url<D>(&self, url: &reqwest::Url) -> ClientResult<(Option<crate::utils::NextLink>, Vec<D>)>
     where
         D: serde::de::DeserializeOwned + 'static + Send,
     {
@@ -399,7 +428,7 @@ impl Client {
         ).await
     }
 
-    async fn post<D>(&self, uri: &str, message: Message) -> Result<D>
+    async fn post<D>(&self, uri: &str, message: Message) -> ClientResult<D>
     where
         D: serde::de::DeserializeOwned + 'static + Send,
     {
@@ -417,7 +446,7 @@ impl Client {
         message: Message,
         media: crate::utils::MediaType,
         authentication: crate::auth::AuthenticationConstraint,
-    ) -> Result<D>
+    ) -> ClientResult<D>
     where
         D: serde::de::DeserializeOwned + 'static + Send,
     {
@@ -430,7 +459,7 @@ impl Client {
         ).await
     }
 
-    async fn patch_media<D>(&self, uri: &str, message: Message, media: crate::utils::MediaType) -> Result<D>
+    async fn patch_media<D>(&self, uri: &str, message: Message, media: crate::utils::MediaType) -> ClientResult<D>
     where
         D: serde::de::DeserializeOwned + 'static + Send,
     {
@@ -443,21 +472,21 @@ impl Client {
         ).await
     }
 
-    async fn patch<D>(&self, uri: &str, message: Message) -> Result<D>
+    async fn patch<D>(&self, uri: &str, message: Message) -> ClientResult<D>
     where
         D: serde::de::DeserializeOwned + 'static + Send,
     {
         self.patch_media(uri, message, crate::utils::MediaType::Json).await
     }
 
-    async fn put<D>(&self, uri: &str, message: Message) -> Result<D>
+    async fn put<D>(&self, uri: &str, message: Message) -> ClientResult<D>
     where
         D: serde::de::DeserializeOwned + 'static + Send,
     {
         self.put_media(uri, message, crate::utils::MediaType::Json).await
     }
 
-    async fn put_media<D>(&self, uri: &str, message: Message, media: crate::utils::MediaType) -> Result<D>
+    async fn put_media<D>(&self, uri: &str, message: Message, media: crate::utils::MediaType) -> ClientResult<D>
     where
         D: serde::de::DeserializeOwned + 'static + Send,
     {
@@ -470,7 +499,7 @@ impl Client {
         ).await
     }
 
-    async fn delete<D>(&self, uri: &str, message: Message) -> Result<D>
+    async fn delete<D>(&self, uri: &str, message: Message) -> ClientResult<D>
     where
         D: serde::de::DeserializeOwned + 'static + Send,
     {
@@ -487,7 +516,7 @@ impl Client {
     async fn unfold<D>(
         &self,
         uri: &str,
-    ) -> Result<Vec<D>>
+    ) -> ClientResult<Vec<D>>
     where
         D: serde::de::DeserializeOwned + 'static + Send,
     {
@@ -1056,7 +1085,7 @@ async fn request<Out>(
     method: reqwest::Method,
     uri: &str,
     message: Message,
-) -> Result<Out>
+) -> ClientResult<Out>
     where
     Out: serde::de::DeserializeOwned + 'static + Send,
 {{
@@ -1094,7 +1123,7 @@ async fn request_with_links<Out>(
     method: http::Method,
     uri: &str,
     message: Message,
-) -> Result<(Option<crate::utils::NextLink>, Out)>
+) -> ClientResult<(Option<crate::utils::NextLink>, Out)>
 where
     Out: serde::de::DeserializeOwned + 'static + Send,
 {{
@@ -1140,7 +1169,7 @@ async fn post_form<Out>(
     &self,
     uri: &str,
     form: reqwest::multipart::Form,
-) -> Result<Out>
+) -> ClientResult<Out>
     where
     Out: serde::de::DeserializeOwned + 'static + Send,
 {{
@@ -1201,7 +1230,7 @@ async fn request_with_accept_mime<Out>(
     method: reqwest::Method,
     uri: &str,
     accept_mime_type: &str,
-) -> Result<Out>
+) -> ClientResult<Out>
     where
     Out: serde::de::DeserializeOwned + 'static + Send,
 {{
@@ -1261,7 +1290,7 @@ async fn request_with_mime<Out>(
     uri: &str,
     content: &[u8],
     mime_type: &str,
-) -> Result<Out>
+) -> ClientResult<Out>
     where
     Out: serde::de::DeserializeOwned + 'static + Send,
 {{
@@ -1334,7 +1363,7 @@ async fn request_entity<D>(
     method: http::Method,
     uri: &str,
     message: Message,
-) -> Result<D>
+) -> ClientResult<D>
 where
     D: serde::de::DeserializeOwned + 'static + Send,
 {{
@@ -1345,7 +1374,7 @@ where
 }}
 
 #[allow(dead_code)]
-async fn get<D>(&self, uri: &str,  message: Message) -> Result<D>
+async fn get<D>(&self, uri: &str,  message: Message) -> ClientResult<D>
 where
     D: serde::de::DeserializeOwned + 'static + Send,
 {{
@@ -1357,7 +1386,7 @@ where
 }}
 
 #[allow(dead_code)]
-async fn get_all_pages<D>(&self, uri: &str,  _message: Message) -> Result<Vec<D>>
+async fn get_all_pages<D>(&self, uri: &str,  _message: Message) -> ClientResult<Vec<D>>
 where
     D: serde::de::DeserializeOwned + 'static + Send,
 {{
@@ -1370,7 +1399,7 @@ where
 async fn unfold<D>(
     &self,
     uri: &str,
-) -> Result<Vec<D>>
+) -> ClientResult<Vec<D>>
 where
     D: serde::de::DeserializeOwned + 'static + Send,
 {{
@@ -1392,7 +1421,7 @@ where
 }}
 
 #[allow(dead_code)]
-async fn get_pages<D>(&self, uri: &str) -> Result<(Option<crate::utils::NextLink>, Vec<D>)>
+async fn get_pages<D>(&self, uri: &str) -> ClientResult<(Option<crate::utils::NextLink>, Vec<D>)>
 where
     D: serde::de::DeserializeOwned + 'static + Send,
 {{
@@ -1404,7 +1433,7 @@ where
 }}
 
 #[allow(dead_code)]
-async fn get_pages_url<D>(&self, url: &reqwest::Url) -> Result<(Option<crate::utils::NextLink>, Vec<D>)>
+async fn get_pages_url<D>(&self, url: &reqwest::Url) -> ClientResult<(Option<crate::utils::NextLink>, Vec<D>)>
 where
     D: serde::de::DeserializeOwned + 'static + Send,
 {{
@@ -1416,7 +1445,7 @@ where
 }}
 
 #[allow(dead_code)]
-async fn post<D>(&self, uri: &str, message: Message) -> Result<D>
+async fn post<D>(&self, uri: &str, message: Message) -> ClientResult<D>
 where
     D: serde::de::DeserializeOwned + 'static + Send,
 {{
@@ -1428,7 +1457,7 @@ where
 }}
 
 #[allow(dead_code)]
-async fn patch<D>(&self, uri: &str, message: Message) -> Result<D>
+async fn patch<D>(&self, uri: &str, message: Message) -> ClientResult<D>
 where
     D: serde::de::DeserializeOwned + 'static + Send,
 {{
@@ -1440,7 +1469,7 @@ where
 }}
 
 #[allow(dead_code)]
-async fn put<D>(&self, uri: &str, message: Message) -> Result<D>
+async fn put<D>(&self, uri: &str, message: Message) -> ClientResult<D>
 where
     D: serde::de::DeserializeOwned + 'static + Send,
 {{
@@ -1452,7 +1481,7 @@ where
 }}
 
 #[allow(dead_code)]
-async fn delete<D>(&self, uri: &str, message: Message) -> Result<D>
+async fn delete<D>(&self, uri: &str, message: Message) -> ClientResult<D>
 where
     D: serde::de::DeserializeOwned + 'static + Send,
 {{
@@ -1472,7 +1501,7 @@ fn get_shared_raw_functions_without_refresh(bearer: &str, post_header_args: &str
 async fn url_and_auth(
     &self,
     uri: &str,
-) -> Result<(reqwest::Url, Option<String>)> {{
+) -> ClientResult<(reqwest::Url, Option<String>)> {{
     let parsed_url = uri.parse::<reqwest::Url>();
     let auth = format!("{} {{}}", self.token);
     parsed_url.map(|u| (u, Some(auth))).map_err(Error::from)
@@ -1483,7 +1512,7 @@ async fn request_raw(
     method: reqwest::Method,
     uri: &str,
     message: Message,
-) -> Result<reqwest::Response>
+) -> ClientResult<reqwest::Response>
 {{
     let (url, auth) = self.url_and_auth(uri).await?;
     let instance = <&Client>::clone(&self);
@@ -1526,7 +1555,7 @@ fn get_shared_raw_functions_with_refresh(bearer: &str, post_header_args: &str) -
 async fn url_and_auth(
     &self,
     uri: &str,
-) -> Result<(reqwest::Url, Option<String>)> {{
+) -> ClientResult<(reqwest::Url, Option<String>)> {{
     let parsed_url = uri.parse::<reqwest::Url>();
 
     let auth = format!("{} {{}}", self.token.read().await.access_token);
@@ -1538,7 +1567,7 @@ async fn make_request(
     method: &reqwest::Method,
     uri: &str,
     message: Message,
-) -> Result<reqwest::Request> {{
+) -> ClientResult<reqwest::Request> {{
     let (url, auth) = self.url_and_auth(uri).await?;
 
     let instance = <&Client>::clone(&self);
@@ -1581,7 +1610,7 @@ async fn request_raw(
     method: reqwest::Method,
     uri: &str,
     message: Message,
-) -> Result<reqwest::Response> {{
+) -> ClientResult<reqwest::Response> {{
     if self.auto_refresh {{
         let expired = self.is_expired().await;
 
@@ -1641,7 +1670,7 @@ pub fn user_consent_url(&self, scopes: &[String]) -> String {{
 
 /// Refresh an access token from a refresh token. Client must have a refresh token
 /// for this to work.
-pub async fn refresh_access_token(&self) -> Result<AccessToken> {{
+pub async fn refresh_access_token(&self) -> ClientResult<AccessToken> {{
     let response = {{
         let refresh_token = &self.token.read().await.refresh_token;
 
@@ -1688,7 +1717,7 @@ pub async fn refresh_access_token(&self) -> Result<AccessToken> {{
 
 /// Get an access token from the code returned by the URL paramter sent to the
 /// redirect URL.
-pub async fn get_access_token(&mut self, code: &str, state: &str) -> Result<AccessToken> {{
+pub async fn get_access_token(&mut self, code: &str, state: &str) -> ClientResult<AccessToken> {{
     let mut headers = reqwest::header::HeaderMap::new();
     headers.append(
         reqwest::header::ACCEPT,
@@ -1730,7 +1759,7 @@ pub async fn get_access_token(&mut self, code: &str, state: &str) -> Result<Acce
 const CLIENT_AUTH_TEMPLATE: &str = r#"
 /// Get an access token from the code returned by the URL paramter sent to the
 /// redirect URL.
-pub async fn get_access_token(&mut self) -> Result<AccessToken> {
+pub async fn get_access_token(&mut self) -> ClientResult<AccessToken> {
     let mut headers = reqwest::header::HeaderMap::new();
     headers.append(
         reqwest::header::ACCEPT,

--- a/generator/src/functions.rs
+++ b/generator/src/functions.rs
@@ -972,7 +972,7 @@ fn get_fn_inner(
                         if e.to_string().contains("404 Not Found") {{
                             page = "".to_string();
                         }} else {{
-                            anyhow::bail!(e);
+                            return Err(e);
                         }}
                     }}
                 }}

--- a/generator/src/functions.rs
+++ b/generator/src/functions.rs
@@ -126,7 +126,7 @@ pub fn generate_files(
                     content.push_str(&format!("body: {}", bp));
                 }
 
-                content.push_str(&format!(") -> Result<{}> {{", response_type));
+                content.push_str(&format!(") -> ClientResult<{}> {{", response_type));
 
                 content.push_str(template);
 

--- a/generator/src/main.rs
+++ b/generator/src/main.rs
@@ -2350,7 +2350,18 @@ fn gen(
 
     a("");
 
-    a("use anyhow::{anyhow, Error, Result};");
+    match proper_name {
+        // Add here project names that were converted to thiserror
+        "GitHub" => {
+            a("use thiserror::Error;");
+            a("type ClientResult<T> = Result<T, ClientError>;");
+        }
+        _ => {
+            a("use anyhow::{anyhow, Error, Result};");
+            a("type ClientResult<T> = Result<T>;");
+        }
+    }
+
     a("");
 
     a(&format!(
@@ -3282,6 +3293,7 @@ serde = {{ version = "1", features = ["derive"] }}
 serde_json = "1"
 serde_urlencoded = "^0.7"
 url = {{ version = "2", features = ["serde"] }}{}{}
+thiserror = "1"
 tokio = {{ version = "1.25.0", features = ["full"] }}
 
 [dev-dependencies]
@@ -3403,8 +3415,10 @@ rustdoc-args = ["--cfg", "docsrs"]
                         tagrs.push(format!("{}.rs", to_snake_case(&clean_name(&f))));
 
                         let output = format!(
-                            r#"use anyhow::Result;
+                            r#"#[allow(unused_imports)]
+use anyhow::Result;
 
+use crate::ClientResult;
 use crate::Client;
 
 {}

--- a/generator/src/main.rs
+++ b/generator/src/main.rs
@@ -2387,7 +2387,10 @@ pub enum ClientError {"#);
             #[error("Rate limited for the next {duration} seconds")]
             RateLimited{
                 duration: u64,
-            },"#);
+            },
+            /// JWT errors from auth.rs
+            #[error(transparent)]
+            JsonWebTokenError(#[from] jsonwebtoken::errors::Error),"#);
         }
         TemplateType::GenericApiKey | TemplateType::GenericClientCredentials => {
             a(r#"/// utf8 convertion error
@@ -2407,7 +2410,11 @@ pub enum ClientError {"#);
 
     // Google Drive only due to traits.rs
     if proper_name == "Google Drive" {
-        a(r#"/// str convertion error
+        a(r#"
+        /// Google Drive not found
+        #[error("{name:?}: Drive not found")]
+        DriveNotFound{name: String},
+        /// str convertion error
         #[error(transparent)]
         ToStrError(#[from] reqwest::header::ToStrError),"#);
     }
@@ -2433,9 +2440,6 @@ pub enum ClientError {"#);
         status: http::StatusCode,
         error: String,
     },
-    /// Generic errors returned by the API.
-    #[error(transparent)]
-    GenericError(#[from] anyhow::Error),
 }
 "#);
 
@@ -3346,7 +3350,6 @@ native-tls = ["reqwest/default-tls", "openssl"]
 rustls-tls = ["reqwest/rustls-tls", "ring", "pem"]
 
 [dependencies]
-anyhow = "1"
 async-recursion = "^1.0"
 chrono = {{ version = "0.4", default-features = false, features = ["serde"] }}
 dirs = {{ version = "^3.0.2", optional = true }}

--- a/github/src/auth.rs
+++ b/github/src/auth.rs
@@ -5,7 +5,7 @@ use std::{
     time,
 };
 
-use anyhow::Result;
+use crate::ClientResult;
 use jsonwebtoken as jwt;
 use serde::Serialize;
 use tokio::sync::RwLock;
@@ -91,7 +91,7 @@ pub struct JWTCredentials {
 }
 
 impl JWTCredentials {
-    pub fn new(app_id: i64, private_key: Vec<u8>) -> Result<JWTCredentials> {
+    pub fn new(app_id: i64, private_key: Vec<u8>) -> ClientResult<JWTCredentials> {
         let creds = ExpiringJWTCredential::calculate(app_id, &private_key)?;
 
         Ok(JWTCredentials {
@@ -133,7 +133,7 @@ struct JWTCredentialClaim {
 }
 
 impl ExpiringJWTCredential {
-    fn calculate(app_id: i64, private_key: &[u8]) -> Result<ExpiringJWTCredential> {
+    fn calculate(app_id: i64, private_key: &[u8]) -> ClientResult<ExpiringJWTCredential> {
         // SystemTime can go backwards, Instant can't, so always use
         // Instant for ensuring regular cycling.
         let created_at = tokio::time::Instant::now();

--- a/google/drive/src/traits.rs
+++ b/google/drive/src/traits.rs
@@ -1,5 +1,8 @@
 #![allow(clippy::field_reassign_with_default)]
-use anyhow::{anyhow, Result};
+use anyhow::anyhow;
+
+use crate::ClientError;
+use crate::ClientResult;
 
 #[async_trait::async_trait]
 pub trait PermissionOps {
@@ -28,7 +31,7 @@ pub trait PermissionOps {
         type_: &str,
         use_domain_admin_access: bool,
         send_notification_email: bool,
-    ) -> Result<crate::types::Permission>;
+    ) -> ClientResult<crate::types::Permission>;
 }
 
 #[async_trait::async_trait]
@@ -58,7 +61,7 @@ impl PermissionOps for crate::permissions::Permissions {
         type_: &str,
         use_domain_admin_access: bool,
         send_notification_email: bool,
-    ) -> Result<crate::types::Permission> {
+    ) -> ClientResult<crate::types::Permission> {
         // First let's check if the permission already exists.
         // List all the permissions for a file.
         let perms = self
@@ -121,7 +124,7 @@ pub trait FileOps {
         drive_id: &str,
         parent_id: &str,
         name: &str,
-    ) -> Result<Vec<crate::types::File>>;
+    ) -> ClientResult<Vec<crate::types::File>>;
 
     /// Create or update a file in a drive.
     /// If the file already exists, it will update it.
@@ -133,19 +136,25 @@ pub trait FileOps {
         name: &str,
         mime_type: &str,
         contents: &[u8],
-    ) -> Result<crate::types::File>;
+    ) -> ClientResult<crate::types::File>;
 
     /// Download a file by it's ID.
-    async fn download_by_id(&self, id: &str) -> Result<bytes::Bytes>;
+    async fn download_by_id(&self, id: &str) -> ClientResult<bytes::Bytes>;
 
     /// Create a folder, if it doesn't exist, returns the ID of the folder.
-    async fn create_folder(&self, drive_id: &str, parent_id: &str, name: &str) -> Result<String>;
+    async fn create_folder(
+        &self,
+        drive_id: &str,
+        parent_id: &str,
+        name: &str,
+    ) -> ClientResult<String>;
 
     /// Get a file's contents by it's ID. Only works for Google Docs.
-    async fn get_contents_by_id(&self, id: &str) -> Result<String>;
+    async fn get_contents_by_id(&self, id: &str) -> ClientResult<String>;
 
     /// Delete a file by its name.
-    async fn delete_by_name(&self, drive_id: &str, parent_id: &str, name: &str) -> Result<()>;
+    async fn delete_by_name(&self, drive_id: &str, parent_id: &str, name: &str)
+        -> ClientResult<()>;
 }
 
 #[async_trait::async_trait]
@@ -156,7 +165,7 @@ impl FileOps for crate::files::Files {
         drive_id: &str,
         parent_id: &str,
         name: &str,
-    ) -> Result<Vec<crate::types::File>> {
+    ) -> ClientResult<Vec<crate::types::File>> {
         let mut query = format!("name = '{}'", name);
         if !parent_id.is_empty() {
             query = format!("{} and '{}' in parents", query, parent_id);
@@ -188,7 +197,7 @@ impl FileOps for crate::files::Files {
         name: &str,
         mime_type: &str,
         contents: &[u8],
-    ) -> Result<crate::types::File> {
+    ) -> ClientResult<crate::types::File> {
         // Create the file.
         let mut f: crate::types::File = Default::default();
         let mut method = reqwest::Method::POST;
@@ -255,7 +264,7 @@ impl FileOps for crate::files::Files {
         // Get the "Location" header.
         let location = match resp.headers().get("Location") {
             Some(location) => location.to_str()?,
-            None => anyhow::bail!("No Location header"),
+            None => return Err(ClientError::GenericError(anyhow!("No Location header"))),
         };
 
         // Now upload the file to that location.
@@ -265,7 +274,7 @@ impl FileOps for crate::files::Files {
     }
 
     /// Download a file by it's ID.
-    async fn download_by_id(&self, id: &str) -> Result<bytes::Bytes> {
+    async fn download_by_id(&self, id: &str) -> ClientResult<bytes::Bytes> {
         let resp = self
             .client
             .request_raw(
@@ -279,7 +288,12 @@ impl FileOps for crate::files::Files {
     }
 
     /// Create a folder, if it doesn't exist, returns the ID of the folder.
-    async fn create_folder(&self, drive_id: &str, parent_id: &str, name: &str) -> Result<String> {
+    async fn create_folder(
+        &self,
+        drive_id: &str,
+        parent_id: &str,
+        name: &str,
+    ) -> ClientResult<String> {
         let folder_mime_type = "application/vnd.google-apps.folder";
         let mut file: crate::types::File = Default::default();
         // Set the name,
@@ -338,7 +352,7 @@ impl FileOps for crate::files::Files {
 
     /// Get a file's contents by it's ID. Only works for Google Docs.
     // TODO: make binary content work in the actual library.
-    async fn get_contents_by_id(&self, id: &str) -> Result<String> {
+    async fn get_contents_by_id(&self, id: &str) -> ClientResult<String> {
         let mut query_ = String::new();
         let query_args = vec!["mime_type=text/plain".to_string()];
         for (i, n) in query_args.iter().enumerate() {
@@ -361,7 +375,12 @@ impl FileOps for crate::files::Files {
     }
 
     /// Delete a file by its name.
-    async fn delete_by_name(&self, drive_id: &str, parent_id: &str, name: &str) -> Result<()> {
+    async fn delete_by_name(
+        &self,
+        drive_id: &str,
+        parent_id: &str,
+        name: &str,
+    ) -> ClientResult<()> {
         // Check if the file exists.
         let files = self
             .get_by_name(drive_id, parent_id, name)
@@ -385,13 +404,13 @@ impl FileOps for crate::files::Files {
 #[async_trait::async_trait]
 pub trait DriveOps {
     /// Get a drive by it's name.
-    async fn get_by_name(&self, name: &str) -> Result<crate::types::Drive>;
+    async fn get_by_name(&self, name: &str) -> ClientResult<crate::types::Drive>;
 }
 
 #[async_trait::async_trait]
 impl DriveOps for crate::drives::Drives {
     /// Get a drive by it's name.
-    async fn get_by_name(&self, name: &str) -> Result<crate::types::Drive> {
+    async fn get_by_name(&self, name: &str) -> ClientResult<crate::types::Drive> {
         let drives = self
             .list_all(
                 //&format!("name = '{}'", name), // query
@@ -405,6 +424,9 @@ impl DriveOps for crate::drives::Drives {
             }
         }
 
-        Err(anyhow!("could not find drive with name: {:?}", name))
+        Err(ClientError::GenericError(anyhow!(
+            "could not find drive with name: {:?}",
+            name
+        )))
     }
 }

--- a/google/sheets/src/traits.rs
+++ b/google/sheets/src/traits.rs
@@ -1,11 +1,11 @@
-use anyhow::Result;
+use crate::ClientResult;
 
 #[async_trait::async_trait]
 pub trait SpreadsheetOps {
     /// Get single cell value.
     /// The `cell_name` is something like `A1` and what is returned is a string representation of
     /// the cell's value.
-    async fn cell_get(&self, sheet_id: &str, cell_name: &str) -> Result<String>;
+    async fn cell_get(&self, sheet_id: &str, cell_name: &str) -> ClientResult<String>;
 }
 
 #[async_trait::async_trait]
@@ -13,7 +13,7 @@ impl SpreadsheetOps for crate::spreadsheets::Spreadsheets {
     /// Get single cell value.
     /// The `cell_name` is something like `A1` and what is returned is a string representation of
     /// the cell's value.
-    async fn cell_get(&self, sheet_id: &str, cell_name: &str) -> Result<String> {
+    async fn cell_get(&self, sheet_id: &str, cell_name: &str) -> ClientResult<String> {
         let values = self
             .values_get(
                 sheet_id,

--- a/rev.ai/src/traits.rs
+++ b/rev.ai/src/traits.rs
@@ -1,17 +1,17 @@
-use anyhow::Result;
+use crate::ClientResult;
 
 #[async_trait::async_trait]
 pub trait JobOps {
     /// Send a plain text email.
     ///
     /// This is a nicer experience than using `post`.
-    async fn post(&self, b: bytes::Bytes) -> Result<crate::types::Job>;
+    async fn post(&self, b: bytes::Bytes) -> ClientResult<crate::types::Job>;
 }
 
 #[async_trait::async_trait]
 impl JobOps for crate::jobs::Jobs {
     /// Create a job.
-    async fn post(&self, b: bytes::Bytes) -> Result<crate::types::Job> {
+    async fn post(&self, b: bytes::Bytes) -> ClientResult<crate::types::Job> {
         let form = reqwest::multipart::Form::new()
             .part(
                 "media",

--- a/sendgrid/src/traits.rs
+++ b/sendgrid/src/traits.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::field_reassign_with_default)]
-use anyhow::{anyhow, Result};
+use crate::ClientError;
+use crate::ClientResult;
 
 #[async_trait::async_trait]
 pub trait MailOps {
@@ -14,7 +15,7 @@ pub trait MailOps {
         cc: &[String],
         bcc: &[String],
         from: &str,
-    ) -> Result<()>;
+    ) -> ClientResult<()>;
 }
 
 #[async_trait::async_trait]
@@ -30,7 +31,7 @@ impl MailOps for crate::mail_send::MailSend {
         ccs: &[String],
         bccs: &[String],
         from: &str,
-    ) -> Result<()> {
+    ) -> ClientResult<()> {
         let mut mail: crate::types::PostMailSendRequest = Default::default();
         mail.subject = subject.to_string();
         mail.from = crate::types::FromEmailObject {
@@ -77,7 +78,10 @@ impl MailOps for crate::mail_send::MailSend {
 
         match resp.status() {
             http::StatusCode::ACCEPTED => Ok(()),
-            s => Err(anyhow!("received response status: {:?}", s)),
+            s => Err(ClientError::HttpError {
+                status: s,
+                error: "Posting to /mail/send".to_string(),
+            }),
         }
     }
 }


### PR DESCRIPTION
[github] Use specialized error

Most, if not all errors, are generated by, or wrapped by, anyhow!.
This causes all errors to look the same from the caller vantage point, preventing
the caller from possibly handling them. For instance, when the API is
rate limited, returning an error that indicates this is a RateLimiting
error, and providing a simple way to know until when we are being rate
limited is valuable. At the moment, one needs to extract the message from the
anyhow error, do some regex magic to detect if this is being rate
limited or not, and extract until when the rate limitation applies.

This change introduces the use of the crate `thiserror` and ports the
github crate to use it.
All crates will now return a `ClientResult` instead of a
`anyhow::Result`. For crates ported to `thiserror`, Client result is an
alias to `Result<T, ClientError>`, where `ClientError` is the enum
defined using `thiserror` to populate variants.
If a crate is not onboarded in `thiserror`, `ClientResult` is a simple
alias to `anyhow::Result`.
