### PR TITLE
[github] fix potential overflow when computing rate limiting duration

### DIFF
--- a/generator/src/client.rs
+++ b/generator/src/client.rs
@@ -317,7 +317,7 @@ impl Client {
                         .duration_since(std::time::UNIX_EPOCH)
                         .unwrap()
                         .as_secs();
-                    anyhow!("rate limit exceeded, will reset in {} seconds", u64::from(reset) - now)
+                    anyhow!("rate limit exceeded, will reset in {} seconds", u64::from(reset).saturating_sub(now))
                 },
                 _ => {
                     if response_body.is_empty() {


### PR DESCRIPTION
There is a change that `SystemTime::now()` is computed the second after the "reset" value, or simply clocks could also be slightly off.

When running in "release" mode, this can lead to an overflow, with the value returned being wrapped to the high u64 values.

https://play.rust-lang.org/?version=stable&mode=release&edition=2021&gist=0c3610ae88babccc0c71ae6e18b07e60

This change ensures that we floor our result to 0 instead of wrapping to u64::MAX