### PR TITLE
[github] Add `HttpCache::in_dir` constructor to allow for custom cache placement

### DIFF
--- a/github/src/http_cache.rs
+++ b/github/src/http_cache.rs
@@ -39,6 +39,16 @@ impl dyn HttpCache {
         dir.push(".github/cache");
         Box::new(FileBasedCache::new(dir))
     }
+
+    pub fn in_dir(path: &Path) -> BoxedHttpCache {
+        if path.is_dir() {
+            let mut path = path.to_owned();
+            path.push(".github/cache");
+            Box::new(FileBasedCache::new(path))
+        } else {
+            panic!("Expected a dir");
+        }
+    }
 }
 
 impl Clone for BoxedHttpCache {

--- a/github/src/http_cache.rs
+++ b/github/src/http_cache.rs
@@ -35,9 +35,7 @@ impl dyn HttpCache {
     }
 
     pub fn in_home_dir() -> BoxedHttpCache {
-        let mut dir = dirs::home_dir().expect("Expected a home dir");
-        dir.push(".github/cache");
-        Box::new(FileBasedCache::new(dir))
+        Self::in_dir(&dirs::home_dir().expect("Expected a home dir"))
     }
 
     pub fn in_dir(path: &Path) -> BoxedHttpCache {


### PR DESCRIPTION
Before only the home dir could be used, this makes it a bit more ergonomic if the user has other desires.