### PR TITLE
[github] method to download URLs from github

### DIFF
--- a/github/Cargo.toml
+++ b/github/Cargo.toml
@@ -18,6 +18,7 @@ rustls-tls = ["reqwest/rustls-tls", "ring", "pem"]
 [dependencies]
 anyhow = "1"
 async-recursion = "^1.0"
+bytes = "1"
 chrono = { version = "0.4", default-features = false, features = ["serde"] }
 dirs = { version = "^3.0.2", optional = true }
 http = "^0.2.4"


### PR DESCRIPTION
structs such as
[Artifact[(https://docs.rs/octorust/latest/octorust/types/struct.Artifact.html) have a field where we can download the artifact.

This download MUST be authenticated or one would get the following error:
```
{
  "message": "You must have the actions scope to download artifacts.",
  "documentation_url": "https://docs.github.com/rest/reference/actions#download-an-artifact"
}
```

The `Client` already has all the details and logic needed for performing an authenticated request. It would be useful to re-use this and expose it to the application using the crate in some ways.

This change adds a naive `get_url` method that given a URL, will download the content and return the raw bytes.