### PR TITLE
[github] Fix compilation wiht httpcache feature enabled

### DIFF
--- a/generator/src/main.rs
+++ b/generator/src/main.rs
@@ -2390,7 +2390,12 @@ pub enum ClientError {"#);
             },
             /// JWT errors from auth.rs
             #[error(transparent)]
-            JsonWebTokenError(#[from] jsonwebtoken::errors::Error),"#);
+            JsonWebTokenError(#[from] jsonwebtoken::errors::Error),
+            /// IO Errors
+            #[cfg(feature = "httpcache")]
+            #[error(transparent)]
+            #[cfg(feature = "httpcache")]
+            IoError(#[from] std::io::Error),"#);
         }
         TemplateType::GenericApiKey | TemplateType::GenericClientCredentials => {
             a(r#"/// utf8 convertion error

--- a/github/src/http_cache.rs
+++ b/github/src/http_cache.rs
@@ -9,7 +9,8 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use anyhow::{Error, Result};
+use crate::ClientResult;
+use crate::ClientError;
 use http::Uri;
 
 /// A type for an HTTP cache.
@@ -23,10 +24,10 @@ pub trait HttpCache: HttpCacheClone + Debug {
         body: &[u8],
         etag: &[u8],
         next_link: &Option<String>,
-    ) -> Result<()>;
-    fn lookup_etag(&self, uri: &str) -> Result<String>;
-    fn lookup_body(&self, uri: &str) -> Result<String>;
-    fn lookup_next_link(&self, uri: &str) -> Result<Option<String>>;
+    ) -> ClientResult<()>;
+    fn lookup_etag(&self, uri: &str) -> ClientResult<String>;
+    fn lookup_body(&self, uri: &str) -> ClientResult<String>;
+    fn lookup_next_link(&self, uri: &str) -> ClientResult<Option<String>>;
 }
 
 impl dyn HttpCache {
@@ -60,16 +61,16 @@ impl Clone for BoxedHttpCache {
 pub struct NoCache;
 
 impl HttpCache for NoCache {
-    fn cache_response(&self, _: &str, _: &[u8], _: &[u8], _: &Option<String>) -> Result<()> {
+    fn cache_response(&self, _: &str, _: &[u8], _: &[u8], _: &Option<String>) -> ClientResult<()> {
         Ok(())
     }
-    fn lookup_etag(&self, _uri: &str) -> Result<String> {
+    fn lookup_etag(&self, _uri: &str) -> ClientResult<String> {
         no_read("No etag cached")
     }
-    fn lookup_body(&self, _uri: &str) -> Result<String> {
+    fn lookup_body(&self, _uri: &str) -> ClientResult<String> {
         no_read("No body cached")
     }
-    fn lookup_next_link(&self, _uri: &str) -> Result<Option<String>> {
+    fn lookup_next_link(&self, _uri: &str) -> ClientResult<Option<String>> {
         no_read("No next link cached")
     }
 }
@@ -94,7 +95,7 @@ impl HttpCache for FileBasedCache {
         body: &[u8],
         etag: &[u8],
         next_link: &Option<String>,
-    ) -> Result<()> {
+    ) -> ClientResult<()> {
         let mut path = cache_path(&self.root, uri, "json");
         //println!("caching body at path: {}", path.display());
         if let Some(parent) = path.parent() {
@@ -110,15 +111,15 @@ impl HttpCache for FileBasedCache {
         Ok(())
     }
 
-    fn lookup_etag(&self, uri: &str) -> Result<String> {
+    fn lookup_etag(&self, uri: &str) -> ClientResult<String> {
         read_to_string(cache_path(&self.root, uri, "etag"))
     }
 
-    fn lookup_body(&self, uri: &str) -> Result<String> {
+    fn lookup_body(&self, uri: &str) -> ClientResult<String> {
         read_to_string(cache_path(&self.root, uri, "json"))
     }
 
-    fn lookup_next_link(&self, uri: &str) -> Result<Option<String>> {
+    fn lookup_next_link(&self, uri: &str) -> ClientResult<Option<String>> {
         let path = cache_path(&self.root, uri, "next_link");
         if path.exists() {
             Ok(Some(read_to_string(path)?))
@@ -185,13 +186,13 @@ pub fn cache_path<S: AsRef<OsStr>>(dir: &Path, uri: &str, extension: S) -> PathB
     path
 }
 
-fn read_to_string<P: AsRef<Path>>(path: P) -> Result<String> {
+fn read_to_string<P: AsRef<Path>>(path: P) -> ClientResult<String> {
     //println!("reading path: {}", path.as_ref().display());
-    fs::read_to_string(path).map_err(Error::from)
+    Ok(fs::read_to_string(path)?)
 }
 
-fn no_read<T, E: Into<Box<dyn std::error::Error + Send + Sync>>>(error: E) -> Result<T> {
-    Err(Error::from(io::Error::new(io::ErrorKind::NotFound, error)))
+fn no_read<T, E: Into<Box<dyn std::error::Error + Send + Sync>>>(error: E) -> ClientResult<T> {
+    Err(ClientError::IoError(io::Error::new(io::ErrorKind::NotFound, error)))
 }
 
 // Separate to provide a blanket implementation for `T: HttpCache + Clone`


### PR DESCRIPTION
In #57, I forgot to test with httpcache feature enabled. There were some anyhow reference left that got exposed during CI.

This change converts `anyhow::Error`s to `ClientError`s and `anyhow::Result`s to `ClientResult`s.

Tested using:

```
 make github && cargo build --features httpcache
--manifest-path=github/Cargo.toml && cargo build
--manifest-path=github/Cargo.toml
./target/debug/generator -i
/data/users/chantra/oxidecomputer-third-party-api-clients/specs/github/api.github.com.json
-v 0.3.2 \
        -o github \
        -n octorust \
        --proper-name GitHub \
        -d "A fully generated & opinionated API client for the GitHub
API." \
        --spec-link "https://github.com/github/rest-api-description" \
        --host "api.github.com"
Only default server urls are supported. Variables are not configurable
component responses not supported
component parameters not supported
component headers not supported
op repos/upload-release-asset: servers are only partially supported.
Variables are not supported
[warn] got ANY kind: Some("instances") code scanning alert AnySchema {
typ: None, pattern: None, multiple_of: None, exclusive_minimum: None,
exclusive_maximum: None, minimum: None, maximum: None, properties: {},
required: [], additional_properties: None, min_properties: None,
max_properties: None, items: None, min_items: None, max_items: None,
unique_items: None, enumeration: [], format: None, min_length: None,
max_length: None, one_of: [], all_of: [], any_of: [], not: None }

cargo fmt -p octorust
   Compiling octorust v0.3.2
(/data/users/chantra/oxidecomputer-third-party-api-clients/github)
    Finished dev [unoptimized + debuginfo] target(s) in 37.66s
   Compiling octorust v0.3.2
(/data/users/chantra/oxidecomputer-third-party-api-clients/github)
    Finished dev [unoptimized + debuginfo] target(s) in 40.35s
```