### PR TITLE
Fix sendgrid send_plain_text

### DIFF
--- a/sendgrid/src/traits.rs
+++ b/sendgrid/src/traits.rs
@@ -32,18 +32,22 @@ impl MailOps for crate::mail_send::MailSend {
         bccs: &[String],
         from: &str,
     ) -> ClientResult<()> {
-        let mut mail: crate::types::PostMailSendRequest = Default::default();
-        mail.subject = subject.to_string();
-        mail.from = crate::types::FromEmailObject {
-            email: from.to_string(),
-            name: String::new(),
+        let mut mail = crate::types::PostMailSendRequest {
+            subject: subject.to_string(),
+            from: crate::types::FromEmailObject {
+                email: from.to_string(),
+                name: String::new(),
+            },
+            content: vec![crate::types::Content {
+                value: message.to_string(),
+                type_: "text/plain".to_string(),
+            }],
+            ..Default::default()
         };
-        mail.content = vec![crate::types::Content {
-            value: message.to_string(),
-            type_: "text/plain".to_string(),
-        }];
-        let mut p: crate::types::Personalizations = Default::default();
-        p.from = Some(mail.from.clone());
+        let mut p = crate::types::Personalizations {
+            from: Some(mail.from.clone()),
+            ..Default::default()
+        };
         for to in tos {
             p.to.push(crate::types::ReplyTo {
                 email: to.to_string(),

--- a/sendgrid/src/traits.rs
+++ b/sendgrid/src/traits.rs
@@ -64,11 +64,12 @@ impl MailOps for crate::mail_send::MailSend {
         }
         mail.personalizations = vec![p];
 
+        let url = self.client.url("/mail/send", None);
         let resp = self
             .client
             .request_raw(
                 reqwest::Method::POST,
-                "/mail/send",
+                &url,
                 crate::Message {
                     body: Some(reqwest::Body::from(serde_json::to_vec(&mail).unwrap())),
                     content_type: None,


### PR DESCRIPTION
The url wasn't getting created correctly, so we just pass it through the method on the trait. I also refactored the method a bit to make clippy happy.

@augustuswm I can also change the default URL to https, wasn't sure if you wanted to fix that elsewhere or just manually here.