### PR TITLE
[github][spec] apply patch from 41a997b when syncing spec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -194,6 +194,7 @@ $(GITHUB_SPEC_DIR):
 
 $(GITHUB_SPEC): $(GITHUB_SPEC_DIR)
 	curl -sSL $(GITHUB_SPEC_REMOTE) -o $@
+	patch -f -p1 < specs/patches/github/*patch 
 
 github: target/debug/generator $(GITHUB_SPEC)
 	./target/debug/generator -i $(GITHUB_SPEC) -v 0.3.2 \

--- a/specs/patches/github/0001-Fix-created-param-format-for-GitHub-workflow-listing.patch
+++ b/specs/patches/github/0001-Fix-created-param-format-for-GitHub-workflow-listing.patch
@@ -1,0 +1,20 @@
+commit 41a997b90c17c3bcc2197db26b8afef4d35fe7c1
+Author: Augustus Mayo <gusmayo@gmail.com>
+Date:   Mon Apr 3 10:27:02 2023 -0500
+
+    Fix created param format for GitHub workflow listing
+
+diff --git a/specs/github/api.github.com.json b/specs/github/api.github.com.json
+index 66bc0e6..5ec536d 100644
+--- a/specs/github/api.github.com.json
++++ b/specs/github/api.github.com.json
+@@ -95467,8 +95467,7 @@
+         "in": "query",
+         "required": false,
+         "schema": {
+-          "type": "string",
+-          "format": "date-time"
++          "type": "string"
+         }
+       },
+       "run-id": {


### PR DESCRIPTION
Test:
```
$ make github
cargo build --bin generator
    Updating crates.io index
   Compiling generator v0.0.0 (/home/chantra/devel/oxidecomputer-third-party-api-clients/generator)
    Finished dev [unoptimized + debuginfo] target(s) in 27.55s
curl -sSL https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.json -o /home/chantra/devel/oxidecomputer-third-party-api-clients/specs/github/api.github.com.json
patch -f -p1 < specs/patches/github/*patch
patching file specs/github/api.github.com.json
Hunk #1 succeeded at 290837 with fuzz 1 (offset 195370 lines).
./target/debug/generator -i /home/chantra/devel/oxidecomputer-third-party-api-clients/specs/github/api.github.com.json -v 0.3.2 \
	-o github \
	-n octorust \
	--proper-name GitHub \
	-d "A fully generated & opinionated API client for the GitHub API." \
	--spec-link "https://github.com/github/rest-api-description" \
	--host "api.github.com"
Only default server urls are supported. Variables are not configurable
component responses not supported
component parameters not supported
component headers not supported
op repos/upload-release-asset: servers are only partially supported. Variables are not supported
[warn] got ANY kind: Some("dismissed_at") code scanning alert created event AnySchema { typ: None, pattern: None, multiple_of: None, exclusive_minimum: None, exclusive_maximum: None, minimum: None, maximum: None, properties: {}, required: [], additional_properties: None, min_properties: None, max_properties: None, items: None, min_items: None, max_items: None, unique_items: None, enumeration: [], format: None, min_length: None, max_length: None, one_of: [], all_of: [], any_of: [], not: None }
...
...
...
```