### PR TITLE
Patched the Users type to have a default for the non-required "custom…

### DIFF
--- a/google/admin/src/types.rs
+++ b/google/admin/src/types.rs
@@ -4107,7 +4107,10 @@ pub struct User {
     /**
      * The Directory API allows you to create and manage your account's users, user aliases, and user Gmail chat profile photos. For more information about common tasks, see the [User Accounts Developer's Guide](/admin-sdk/directory/v1/guides/manage-users.html) and the [User Aliases Developer's Guide](/admin-sdk/directory/v1/guides/manage-user-aliases.html).
      */
-    #[serde(rename = "customSchemas")]
+    #[serde(
+        default,
+        rename = "customSchemas"
+    )]
     pub custom_schemas:
         std::collections::HashMap<String, std::collections::HashMap<String, serde_json::Value>>,
     /**


### PR DESCRIPTION
…_scehmas" field

Without having the default, serde will throw 'Err(expected `,` or `}` at line 53 column 5)' when trying to deserialize a User resource.

Since this library is fully generated, my guess is either the generator module in this repo needs a tweak or the OpenAPI Spec from [APIs-guru/openapi-directory](https://github.com/APIs-guru/openapi-directory/blob/main/APIs/googleapis.com/admin/directory_v1/openapi.yaml) does. 