### PR TITLE
Mention the openapi generator used in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,9 @@ A place for keeping all our generated third party API clients.
 - [Stripe](stripe/) [![docs.rs](https://docs.rs/dolladollabills/badge.svg)](https://docs.rs/dolladollabills)
 - [TripActions](tripactions/) [![docs.rs](https://docs.rs/tripactions/badge.svg)](https://docs.rs/tripactions)
 - [Zoom](zoom/) [![docs.rs](https://docs.rs/zoom-api/badge.svg)](https://docs.rs/zoom-api)
+
+## Generator
+
+The generator lives in the [generator](https://github.com/oxidecomputer/third-party-api-clients/tree/main/generator) directory.
+It generates the entirety of the crates including their `README.md` and `Cargo.toml`.
+This project does not use [progenitor](https://github.com/oxidecomputer/progenitor) or [openapi-generator](https://github.com/oxidecomputer/openapi-generator).


### PR DESCRIPTION
Its very easy to miss the `generator` directory amongst all the generated crates.
I spent a while inspecting progenitor and oxide's fork of openapi-generator before I realized that neither of them was used for this repo.
So I am adjusting the readme to make this clearer for future readers.