### PR TITLE
fix freebusy serializer

### DIFF
--- a/google/calendar/src/types.rs
+++ b/google/calendar/src/types.rs
@@ -1,8 +1,7 @@
 //! The data types sent to and returned from the API client.
-use std::collections::HashMap;
-
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone, JsonSchema)]
 pub struct Acl {

--- a/google/calendar/src/types.rs
+++ b/google/calendar/src/types.rs
@@ -1,4 +1,6 @@
 //! The data types sent to and returned from the API client.
+use std::collections::HashMap;
+
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -1904,8 +1906,7 @@ pub struct FreeBusyResponse {
     /**
      * List of free/busy information for calendars.
      */
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub calendars: Option<FreeBusyCalendar>,
+    pub calendars: HashMap<String, FreeBusyCalendar>,
     /**
      * Expansion of groups.
      */
@@ -2040,23 +2041,11 @@ pub struct TimePeriod {
     /**
      * Last modification time of the color palette (as a RFC3339 timestamp). Read-only.
      */
-    #[serde(
-        default,
-        skip_serializing_if = "Option::is_none",
-        deserialize_with = "crate::utils::date_time_format::deserialize",
-        serialize_with = "crate::utils::google_calendar_date_time_format::serialize"
-    )]
-    pub end: Option<chrono::DateTime<chrono::Utc>>,
+    pub end: chrono::DateTime<chrono::Utc>,
     /**
      * Last modification time of the color palette (as a RFC3339 timestamp). Read-only.
      */
-    #[serde(
-        default,
-        skip_serializing_if = "Option::is_none",
-        deserialize_with = "crate::utils::date_time_format::deserialize",
-        serialize_with = "crate::utils::google_calendar_date_time_format::serialize"
-    )]
-    pub start: Option<chrono::DateTime<chrono::Utc>>,
+    pub start: chrono::DateTime<chrono::Utc>,
 }
 
 /**


### PR DESCRIPTION
I know this repo is autogenerated, but this change fixes empty freebusy calls. 

Pre-fix response body:
```sh
Response {
    status: 200,
    headers: {
        ...
    },
    body: FreeBusyResponse {
        calendars: Some(
            FreeBusyCalendar {
                busy: [],
                errors: [],
            },
        ),
        groups: None,
        kind: "calendar#freeBusy",
        time_max: Some(
            2025-11-20T13:59:03.215Z,
        ),
        time_min: Some(
            2025-11-06T13:59:03.215Z,
        ),
    },
}
```
Post-fix response body
```sh
Response {
    status: 200,
    headers: {
       ...
    },
    body: FreeBusyResponse {
        calendars: {
            "somerandomid@...": FreeBusyCalendar {
                busy: [
                    TimePeriod {
                        end: 2025-11-12T21:30:00Z,
                        start: 2025-11-12T20:00:00Z,
                    },
                    TimePeriod {
                        end: 2025-11-14T21:00:00Z,
                        start: 2025-11-14T20:00:00Z,
                    },
                    TimePeriod {
                        end: 2025-11-17T17:30:00Z,
                        start: 2025-11-17T16:30:00Z,
                    },
                ],
                errors: [],
            },
            "somerandomid@...": FreeBusyCalendar {
                busy: [
                    TimePeriod {
                        end: 2025-11-06T17:00:00Z,
                        start: 2025-11-06T16:00:00Z,
                    },
                    TimePeriod {
                        end: 2025-11-07T07:45:00Z,
                        start: 2025-11-07T00:15:00Z,
                    },
                ],
                errors: [],
            },
        },
        groups: None,
        kind: "calendar#freeBusy",
        time_max: Some(
            2025-11-20T14:00:56.711Z,
        ),
        time_min: Some(
            2025-11-06T14:00:56.711Z,
        ),
    },
}
```